### PR TITLE
docs: Add FAQ for soln to Livestreaming not visible in IPFS Youtube Channel

### DIFF
--- a/HOST_A_CALL.md
+++ b/HOST_A_CALL.md
@@ -78,7 +78,8 @@ If you are hosting and need access to the vault, send an email to it@protocol.ai
 
 ## FAQ
 
-- **Do I need a special account to be the host?** No, all you need is to ask to be added to the list of hosts so that you have recording and livestreaming capabilities. Do this by asking one of the current hosts or sending an email to it@protocol.ai
+- **What do I do if the Livestream doesn't show up on the IPFS Youtube Channel?** It is important that the live stream privacy setting under "basic info" be set to "public", otherwise the livestream won't show up on the IPFS channel or on our link https://www.youtube.com/c/IPFS-dweb/live. If you see the livestream coming through the live dashboard but not on our channel, that's probably the issue. We still check the box to "Automatically make archive unlisted once the stream has ended" so that we can rename and update the recording after the call. 
+- **Do I need a special account to be the host?** No, all you need is to ask to have your personal email address added to the list of hosts so that you have recording and livestreaming capabilities. Do this by asking one of the current hosts or sending an email to it@protocol.ai
 - **Who currently has delegated hosting ability per call (and can therefore can record/livestream if needed)?**
   - IPFS All Hands Call: david@protocol.ai, matt@protocol.ai, erik@carbonfive.com, victor@protocol.ai, molly@protocol.ai
   - JS Core Dev Weekly Sync: jake@andyet.net, alan.shaw@protocol.ai, david@protocol.ai, molly@protocol.ai


### PR DESCRIPTION
I started filing this as an issue - but I figured out the solution (\o/) so adding it to our call notes FAQ. FYI @pkafei 

Context: We normally stream our Weekly All Hands call to https://www.youtube.com/c/IPFS-dweb/live - however our last few calls haven't been available there, nor visible on our IPFS channel while the call is happening. The call is correctly associated with the YouTube account and shows up on the livestream dashboard (https://www.youtube.com/live_dashboard), however it isn't visible on the channel or the /live link. 

Solution: Turns out this is because the livestream channel privacy setting got changed to "unlisted" - which means it isn't findable by anyone except the ipfs owner account and isn't displayed on our channel. Changing that back to "public" made this viewable and makes our links work again! yay!