### PR TITLE
Move meeting notes for GUI and In Web Browsers WGs

### DIFF
--- a/meeting-notes/2017/2017-03-29--in-web-browsers-standup.md
+++ b/meeting-notes/2017/2017-03-29--in-web-browsers-standup.md
@@ -1,0 +1,35 @@
+Participants:
+- @diasdavid
+- @JayCarpenter
+- @lgierth
+
+Recording: https://ipfs.io/ipfs/QmYUbamFQLbmHc4WiBr2jhJrZeCtQHN3U59ixW3QCEdBgM
+
+### updates
+
+@lgierth
+- refining relay spec
+- got ssl certs for /ws bootstrappers
+  - TOO bump proxy_read_timeout to 30
+- next: /ws transport on go-ipfs gateway
+- nextnext: configurable announced addresses
+
+@jaycarpenter
+- have been hopping on irc and continuing to get oriented regarding the whole ecosystem
+- not working on a specific item at the moment
+
+@daviddias
+- @dignifiedquire implemented dht module
+- @daviddias implementing dht module integration
+- refining relay spec
+- supporting @drjayov implementing relay
+- debugged /ws bootstrappers with @lgierth
+- js-libp2p-record shipped
+- next: getting dht work finished
+
+### observations
+
+- it's good to have the implementers directly focused on, and involved in, spec work
+- it was also useful to have a baseline with the general approach direction already in place
+  - because it was already a month or two old, there was time to let it sink in
+  - this allowed for very focused and productive refinement discussions right from the start

--- a/meeting-notes/2017/2017-10-02--lab-week-discussions-on-ipfs-in-browser-extension.md
+++ b/meeting-notes/2017/2017-10-02--lab-week-discussions-on-ipfs-in-browser-extension.md
@@ -1,0 +1,137 @@
+# Roadblocks for IPFS in Browser Extension
+
+This memo is a summary of various conversations we had during
+Lab Week for Q4 2017, starting with unconf session on Monday.
+
+> **TL;DR**
+> - Right now, [ipfs-companion](https://github.com/ipfs/ipfs-companion) requires external daemon and _just pretends_ to support `ipfs://`, `dweb:` protocols,
+> - we've identified Three Problems that need to be solved to have IPFS running natively in browser extension,
+> - creation of [Programmable Protocol Handler API](#new-native-programmable-protocol-handler-api-for-webextensions) would solve all of them.
+
+# Identified Problems
+
+## Problem #1: Inability to Inject HTTP Responses by WebExtension
+
+It is possible to run js-ipfs node in extensions background page, but when it
+comes to major players in browser space we are missing WebExtension API that
+"enables the extension to satisfy hijacked HTTP request by injecting response read by js-ipfs".
+
+As of now (2017) [`browser.webRequest`][2] API makes it possible to:
+
+- cancel the request in `onBeforeRequest`, `onBeforeSendHeaders` and `onAuthRequired`
+- redirect the request in `onBeforeRequest`, `onHeadersReceived`
+- modify request headers in `onBeforeSendHeaders`
+- modify response headers in `onHeadersReceived`
+- supply authentication credentials in `onAuthRequired`
+
+What is missing are means of providing response payload instead of redirection
+in `onBeforeRequest` step of request life cycle.
+
+
+## Problem #2: Inability to Control How Origin Is Calculated
+
+Web security model relies on [Same-origin policy][3].
+
+This introduces two major inconveniences for websites loaded via IPFS2HTTP gateways (serving content from `/ipfs/` and `/ipns/` paths):
+
+- every IPFS gateway has different Origin, making it impossible for a user to persist state while switching gateways
+- an Origin of a single gateway is shared by all sites loaded from it, making it impossible to write secure web apps
+
+Some people solve this by creating artificial subdomains that have URL-safe CID
+in them (`$cid.ipfs.dweb.link`). A subdomain provides separate Origin and
+creates an isolated security context.
+
+Unfortunately, this is not possible for a gateway running on `127.0.0.1`.
+
+
+## Problem #3: Inability to Control Address in Location Bar
+
+This is a major UX issue.
+
+We should  have:
+
+```
+dweb:/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
+```
+
+instead of:
+
+```
+http://127.0.0.1:8080/ipfs/QmbWqxBEKC3P8tqsKc98xmWNzrzDtRLMiMPL8wBuTGsMnR
+```
+
+
+# Possible Solutions
+
+## Temporary Hacks and Partial Workarounds
+
+[Problem #1](#problem-1-inability-to-inject-http-responses-by-webextension) might be (partially) solved with:
+
+### Creative Use of Service Worker
+
+We could have js-ipfs running inside of a Service Worker acting as a 'proxy'
+for  HTTP requests to the public gateway.
+
+See demo and PoC at [IPFS runs as a Service Worker][6].
+
+  - Good:
+    - service worker can inject responses for a host it was installed from
+    - if we provide Service Worker for the public gateway, and browser
+      extension redirects everything to public gateway, then we are able to handle all IPFS requests
+    - transparent for the end user
+  - Bad
+    - a user needs to visit regular HTTP site to install Service Worker
+        - Really bad: [service worker must be refreshed/downloaded every 24h][7]
+    - if we want to solve [#2](#problem-2-inability-to-control-how-origin-is-calculated) we need to have separate service worker for every gateway/root CID
+    - no connection closing + global Service Worker = memory leaks
+    - does not address [#3](#problem-3-inability-to-control-address-in-location-bar)
+
+### Extending `webRequest` API to Support Response Injection
+
+In theory, extending existing `browser.webRequest` APIs to support response
+generation (e.g. from within `onBeforeRequest` hook) would enable us to hijack
+requests and respond with data read via js-ipfs.
+
+There is a very low probability that such API change will happen, these APIs were designed this way with certain security constraints in mind.
+
+Even if it would happen, it would not address problems [#2](#problem-2-inability-to-control-how-origin-is-calculated) and [#3](#problem-3-inability-to-control-address-in-location-bar).
+
+## New, Native, Programmable Protocol Handler API for WebExtensions
+
+What we really need is a new WebExtension API that lets us define a programmable protocol
+handler.
+
+Such API should enable browser extension to do three things:
+
+1. Respond to `dweb:` requests with actual payload (no redirect to HTTP).
+
+   To be more specific, WebExtension should be able to provide function that
+   takes a URI and returns `new Response(data, headers)`
+
+2. Control how _Origin_ is calculated.
+
+   In case of `/ipfs/$cid`, every CID would have its own Origin.
+
+3. Display and support use of `dweb:` address in GUI (location bar, bookmarks, etc)
+
+   This would not only improve user experience but also enable us to use `dweb:` links by default.
+
+The good news is that creation of such API was already proposed in [Bug 1271553: Add ability to implement programmable custom protocol handler][4].
+
+The bad news is that it won't happen this year, as most of the engineering efforts at Mozilla are focused on [Firefox Quantum][5] release.
+
+Still, this is the best way to solve our Three Problems.
+
+We should advocate creation of such API, as it would not only enable us to do
+great things with IPFS browser extension, but could enable Firefox to become an
+application platform.
+
+
+[1]: https://github.com/ipfs/js-ipfs
+[2]: https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/WebRequest
+[3]: https://en.wikipedia.org/wiki/Same-origin_policy
+[4]: https://bugzilla.mozilla.org/show_bug.cgi?id=1271553
+[5]: https://www.mozilla.org/en-US/firefox/quantum/
+[6]: https://github.com/ipfs/in-web-browsers/issues/55
+[7]: https://github.com/w3c/ServiceWorker/issues/514
+

--- a/meeting-notes/2017/2017-12-29--in-web-browsers-q1-planning-brainstorming.md
+++ b/meeting-notes/2017/2017-12-29--in-web-browsers-q1-planning-brainstorming.md
@@ -1,0 +1,91 @@
+# IPFS in Web Browsers Q1 Planning/Brainstorming (I)
+
+## Attendees
+
+- @diasdavid
+- @olizilla
+- @lidel
+- @dmitriy
+- @kyledrake
+- @flyingzumwalt
+
+# Agenda
+- Overview
+- Forming the working group
+	- What is the purpose of the WG
+- Checking in with the context
+- Setting OKRs
+
+## Notes
+
+First official meeting of the not yet official IPFS in Web Browsers working group.
+
+### Forming the Working Group
+
+**[Current Working Groups Proposal](https://github.com/ipfs/ipfs/blob/8dc70f4d9676b181734c7818908f422af8fb47f5/WORKING_GROUPS.md#integration-with-web-browsers)**
+
+What is the purpose of the WG? What does the IPFS world think a WG is?
+
+We want it to be clear what the community should expect from a WG.
+
+Some things we're leaving loose or undefined for now:
+- does the WG control a repo?
+- where is their work tracked?
+- Is there a procedure for discussions, decisions, etc?
+
+Some desirable characteristics for WGs
+- If you have KRs for the WG it should be hard to pull you off that.
+- It should be welcoming/inviting for people to join and participate
+- (as specified in the proposal) there should be a captain and a co-captain 
+
+
+### Context (checking in, getting synced)
+
+- lidel's proposed OKRs: https://github.com/ipfs/in-web-browsers/pull/62
+  - these are only for browser extension
+  - a starting point for further discussion
+
+Lots of ideas and conversations already floating around
+- kyle's thoughts about UX
+- address scheme discussions ... [The four stages of the upgrade path for path addressing](https://github.com/ipfs/specs/pull/152#issuecomment-284628862) ... 
+
+Use Cases
+- persistence layer for a dapp developers (Open Bazaar use case)
+- IPFS as filesystem ... nice distributed filesystem
+- IPFS for serving/publishing web pages
+- IPFS the distributed web ... getting 2 billion to use something that works better than HTTP
+
+
+### Setting OKRs
+
+**TASK**: Extract the document that defines the ultimate dream for IPFS in web browsers and expresses what to do in the next 3 months
+- this mainly involves gathering all the info that's floating around out there, putting it in one clear document
+
+Proposal: revisit kyle's "screed" proposal, update that and use it as the defining UX vision.
+- the only part that people have disagreed with is the idea of creating our own browser
+- if we don't build our own browser we will need to set someone up as our lobbyist connecting with the browser manufacturers 
+
+#### Possible KRs
+
+- Understand what is the ideal UX and agree on it (multiple iterations)
+- create a browser demo that shows the browser manufacturers how it _should_ work (some misgivings about whether this is the right way to spend effort)
+	- cost-effective alternative: [Create WebExtensions Experiments to Prototype Missing APIs](https://github.com/ipfs-shipyard/ipfs-companion/issues/343)    
+      ([WebExtension Experiment](https://webextensions-experiments.readthedocs.io/en/latest/)  + demo use in IPFS Companion)
+	- expensive alternative: fork firefox as a demo -- this is how Tor Browser works, and how they propose features within the firefox team 
+- create a "Call to Arms" that tells and shows why this is important and how it should work
+- Establish a style guide for IPFS apps in the browser
+- spring cleaning -- clean up the in-web-browsers repo. update issues, update docs, etc.
+	- make the web-browsers repo into a reliable reference point for anyone interested in this effort 
+  
+Straw Poll of Group's Priorities
+- Making IPFS look & work well
+	- are we distributed yet?
+
+# Action Items 
+- submit PRs with OKR proposals ([OKR.md](https://github.com/ipfs/in-web-browsers/blob/master/OKR.md))
+  - everyone declare what they want to work on (pitch your own goal)
+- create a channel in irc 
+- meet again in 10 days (around 8-10 January)
+- spring-cleaning https://github.com/ipfs/in-web-browsers/issues
+
+

--- a/meeting-notes/2017/2018-01-09--in-web-browsers-q1-planning-brainstorming.md
+++ b/meeting-notes/2017/2018-01-09--in-web-browsers-q1-planning-brainstorming.md
@@ -1,0 +1,42 @@
+# 2018-01-09: IPFS in Web Browsers Q1 Planning/Brainstorming (II)
+
+
+## Attendees
+
+- Matt Zumwalt
+- Alan Shaw
+- @olizilla
+- David Dias
+- @lidel
+
+## Agenda
+
+- **Review OKR**
+	- Discussed `OKR.md` draft, fleshed out some action items:
+		- reword _"Embedded js-ipfs runs in Brave without installing external daemon"_ to something like _"Identify and document missing pieces to run a reliable embedded js-ipfs in Brave (without installing external daemon)"_
+		- reword _"Improved initial experience for non-technical users of mainstream browsers"_
+			- focus KRs on Fleshing out user stories/journeys and create UX/style guides
+		- fold "Brave  one" into a KR under "Structure documentation and discussion around the primary Browser vendor concerns"
+    - Everyone will do one more iteration in a single PR
+    - ... then move OKRs to Google Spreadsheet and add assignments and priorities
+- PSA: Started GUI/UX initiative at https://github.com/ipfs-shipyard/pm-ipfs-gui
+	- PSA: Started work on UX/Style Guide: https://github.com/ipfs-shipyard/ipfs-ui-style-guide
+-  Briefly introduce a Person of Interest to new team members :-)
+	- @gozala is a valuable point of contact/discussions for dweb integration with browsers (Beaker etc)
+- Spring cleaning in progress
+- Identified need for coherent documentation of addressing on the dweb
+  - current state of addressing spec: https://github.com/ipfs/specs/tree/addressing/dweb-addressing
+- `arewedistributedyet.com` kick-off
+  - Tracked in [existing epic @ ipfs/in-web-browsers](https://github.com/ipfs/in-web-browsers/issues/24#issuecomment-355942618)
+  - Registered Domain Name: AREWEDISTRIBUTEDYET.COM
+
+## Appendix
+
+### Q:
+- where is the line between functionality that’s only available in node vs func that’s available in browsers?
+
+### A:
+- Anything that's in IPFS-core spec should be available in browsers and in node (Everywhere)
+- tl;dr anything that interfaces with the OS is tricky or different in browsers. mostly: libp2p transport and discovery, and ipfs datastore (and also different between language runtimes, js/go/rust, depending on the availability and quality of libraries)
+- IPFS should be figuring out how to talk to other nodes, but in some cases this doesn't work within the browser. We are working to address those cases.
+

--- a/meeting-notes/2018/2018-04-03--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-04-03--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,35 @@
+# In Web Browsers and GUIs: Weekly IRC Sync (2018-04-03)
+
+Participants:
+- #ipfs-in-web-browsers
+
+## Agenda
+
+- What did you work on last week, what are you working on this week?
+- [Q2 OKRs!](https://github.com/ipfs/in-web-browsers/issues/78)
+  - [Q2 OKR sheet](https://docs.google.com/spreadsheets/d/1xIhKROxFlsY9M9on37D5rkbSsm4YtjRQvG2unHScApA/edit#gid=755202447)
+  - Decisions:
+      - **AI @all**: Add yourself to OKRs as you feel appropriate
+      - **AI @lidel**: ping Matt/David for feedback 
+- GUIs (**AI @ all**)
+  - Share WebUI look'n'feel inspirations
+  - Write up ideal UX definitions
+  - Wireframes
+  - Accessibility testing
+    -  https://github.com/pa11y/pa11y
+    -  Seek advice on how to do well
+        -  Provide feedback and ideas in  https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/28
+  - Tech choices
+    - Review proposal: https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/51
+- In web browsers
+  - Companion release v2.2.0
+    - [try the chrome beta channel](https://chrome.google.com/webstore/detail/ipfs-companion-dev-build/hjoieblefckbooibpepigmacodalfndh)
+    - **AI @ lidel**: write RN and blogpost, QA, release & press "post"
+  - Brave chat (all is chromium now)
+    - https://brave.com/development-plans-for-upcoming-release/
+    - **AI @ lidel, olizilla**
+  - Comms channel for p2p and browser devs
+  - arewedistributedyet
+
+## Action Items
+Marked inline in agenda as **AI**

--- a/meeting-notes/2018/2018-04-09--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-04-09--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,62 @@
+# In Web Browsers and GUIs: Weekly IRC Sync (2018-04-09)
+
+- **Lead:** @lidel
+- **Notetaker:** @lidel
+- **Attendees:**
+  - @lidel
+  - @alanshaw
+  - @hacdias
+  - @agata_krych
+ 
+
+## Agenda
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+- Brave call update please!
+- Plan this week
+- Review remaining issues if there is time left
+
+
+## Notes
+
+### IPFS Companion v.2.2.0
+- [Release  Notes](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.2.0)
+    - blog post later this week
+
+### "the gallery thingy like experiments.google.com"
+
+- Continue discussion in https://github.com/ipfs/awesome-ipfs/issues/126
+    - if we add tags to awesome-ipfs  somehow, that will make things super easy to share (eg. share demos that use window.ipfs, share)
+
+### Brave Call Notes
+
+Brave is moving away from Muon (electron fork) and will use Chromium fork instead:
+- https://brave.com/development-plans-for-upcoming-release/
+
+We (@olizilla, @diasdavid and @lidel) had a call with Brave team last week to figure out where we stand and what will be the future of IPFS in "new Brave".
+
+IPFS call summary created by Brave team:
+> - [IPFS team] have been working on a Muon based approach, but it sounds like have been blocked on some things.
+> - The IPFS guys are willing to spend more time on integration within Brave especially if we can improve responsiveness.
+> - It sounds like we should re-use the web-extension based ipfs-companion extension: https://chrome.google.com/webstore/detail/ipfs-companion/nibjojkomfdiaoajekhjakgkdhaomnch and https://github.com/ipfs-shipyard/ipfs-companion
+> - [IPFS team] is interested in leveraging Chrome App APIs (and possibly custom ones Brave would create) to give them the functionality they need to innovate for what a P2P browser would be.
+> - Oli will work on getting a brave-core build up and working.
+> - The ipfs-companion extension needs a separately installed locally running IPFS daemon from what I understand. We could do like Tor does to bundle the daemon with Brave.
+> - We might introduce a bi-weekly call once work starts heating up, first step get them running on a chromium-fork build.
+
+**tl;dr** It is a mixed bag, but in the long run we may end up with more powerful apis, such as [socket API](https://developer.chrome.com/apps/socket). We may need to adjust our OKRs for Q2 to account for these new Brave efforts.
+
+### GUI Design 
+
+- Agatha is finishing wireframes for start page, nothing to link yet, expect an update soon. 
+    - We will try Invision for comments this time (may be more friendly than Zeplin)
+- Next step will be File Browser
+    - Design: Add files to IPFS https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/35
+    - Design: File Browser https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/9

--- a/meeting-notes/2018/2018-04-16--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-04-16--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,96 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-04-16
+
+- **Lead:** @lidel
+- **Notetaker:** @olizilla
+- **Attendees:**
+  - alanshaw
+  - olizilla
+  - lidel
+  - jonkrone
+  - kyledrake
+  - agatakrych
+  - hacdias
+
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+- Updated OKRs for Q2 after initial feedback from David
+- What should be the first step for Brave integration?
+- Splitting GUI WG?
+- where are we with WebUI? 
+    - will [name change](https://github.com/ipfs-shipyard/ipfs-webui/issues/612) happen?
+    - does it make sense to start building backed in a new branch?
+- Review remaining issues if there is time left
+- IPFS branch in Beaker
+- Tech choices https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/51
+
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Beaker Browser working on read-only ipfs support.
+
+- https://github.com/beakerbrowser/beaker/tree/ipfs-readonly
+- Let's ask what their plan is for implementation (external daemon, or embedded node?), and help make this a thing.
+
+
+### ipfs-companion v2.2.1 released. 
+
+- Feedback on v2.2 rolling in, issues getting fixed. https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.2.1
+- Discussion needed on hide window.ipfs from sites (privacy / fingerprinting) https://github.com/ipfs-shipyard/ipfs-companion/issues/451
+
+
+### Awesome-ipfs and demo apps
+
+- IPFS Bandwidth viewer https://tableflip.github.io/ipfs-peer-bw-example/dist/
+- Building apps is helping us find the apis we need https://github.com/ipfs/go-ipfs/issues/4740#issuecomment-381546347
+- Work started on building the cataglog https://github.com/hacdias/awesome-ipfs
+- Work in progress on a "share files" demo
+- Adding ipfs.types and ipfs.util to window.ipfs via ipfs-postmsg-proxy
+- Perf concerns around adding window.ipfs to evey page. Profiling needed. https://github.com/ipfs-shipyard/ipfs-companion/issues/460
+
+
+### Brave integration
+
+- Switched focus to "nu-Brave" (the internal codename for the chromium based rebuild of Brave.)
+- ipfs-companion currently works without modification in nu-Brave.
+- Oli to update Brave and seek guidance on bundling go-ipfs deamon with Brave.
+
+
+### More input needed on arewedistributedyet.com
+
+- Agata has created some rad designs https://github.com/ipfs-shipyard/arewedistributedyet/issues/16
+- Oli to arrange a call to get more input on technical discussion
+
+
+### WebUI redesign
+
+- We had first iteration on WebUI Wireframes for start/status page. https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/33#issuecomment-380017873
+- Next iteration on start/status and first draft of the files page this week.
+- Demo apps are proving out functionality that will be needed for the new WebUI, once designs are ready.
+- Oli to arrange a call with jonkrone about overlap with peerbox, webui, companion and all the things. https://github.com/ipfs-shipyard/peer-star/issues/1 and https://github.com/ipfs-shipyard/pm-ipfs-gui/issues?q=is%3Aissue+is%3Aopen+label%3A%22existing+feature%22
+- Tech choices to be finalised for nest weeks catchup https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/51
+- Discussion of a name change for WebUI is on hold until we've got designed and built.
+- Need to find out if using aegir is a requirement, and if so, find a champion to make it happen.
+
+
+### Other business
+
+- Q2 OKRs re-worked after feedback https://docs.google.com/spreadsheets/d/1xIhKROxFlsY9M9on37D5rkbSsm4YtjRQvG2unHScApA/edit#gid=755202447
+- Hello jonkrone o/

--- a/meeting-notes/2018/2018-04-23--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-04-23--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,51 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-04-23
+
+- **Lead:** lidel
+- **Notetaker:** olizilla
+- **Attendees:**
+  - @hacdias
+  - @lidel
+  - @olizilla
+  - @alanshaw
+  - @agata_krych
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+- Share files demo is a thing https://ipfs.io/ipns/share.tableflip.io/
+- Wireframe of File Browser - view&comment at https://projects.invisionapp.com/share/AVGRKKJ75KT#/screens/292909648/comments
+- Brave update
+- Are We Distributed Yet update
+
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+- IPLD Explorer cli is a thing https://www.youtube.com/watch?v=AgjSBT3RQvg
+- Wireframe for WebUI files page https://projects.invisionapp.com/share/AVGRKKJ75KT#/292909648_File_Webui_Wireframe
+  - **Feedback wanted.** Leave comments in invision.
+- No time available on Awesome IPFS last week, but this week looks good.
+- Share files demo is a thing https://ipfs.io/ipns/share.tableflip.io/
+  - Hit lots of issues. PRs and reports have been sent.
+  - No streaming yet.
+  - Feedback and PRs welcome: https://github.com/tableflip/share-via-ipfs
+- Finding and fixing issues around streams and ipfs.add and dht.findprovs
+- Brave are keen to bundle go-ipfs with nu-brave. Waiting on guidance from them.
+- arewedistributedyet interviews to start this week. Get timeboxed braindumps from specific people.
+- Content Origin / Security Context doc added http://arewedistributedyet.com/control-origin-security-context/
+- Work started on 'Addressing on the Decentralized Web' spec

--- a/meeting-notes/2018/2018-04-30--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-04-30--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,72 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-04-30
+
+- **Lead:** @lidel
+- **Notetaker:** {@lidel}
+- **Attendees:**
+  - @lidel
+  - @agata_krych
+  - @olizilla
+  - @hacdias
+  - @alanshaw
+
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+- WebUI update
+- Goals for Lisbon Hack Week
+- Should we move sync 1h earlier? or to other day?
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Browser Extension
+
+* Researched `window.ipfs` perf
+	* TLDR; the content scripts also add constructor @ `window.Ipfs`, this adds a **~500ms** delay, suggested removing it
+
+### New WebUI
+
+* Started work on WebUI 2.0 foundations
+	* Tech Stack
+		* Started by using Aegir found a few pain points
+		* Looked into options for e2e testing and found Google's Puppeteer to be least flakey, quickest, and free
+		* All findings written up here: https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/51#issuecomment-385425256
+	* Reviewing wireframes
+		*  [Drag and drop](https://invis.io/AVGRKKJ75KT#/293709612_File_screen_-_drag-drop_in_subfolder)
+		*  [Share single file](https://invis.io/AVGRKKJ75KT#/293742323_Share_screen_-_single_item)
+		*  [Share a few files](https://invis.io/AVGRKKJ75KT#/293763510_Share_screen_-_few_items)
+		*  [Share folder](https://invis.io/AVGRKKJ75KT#/293767639_Share_screen_-_folder)
+	* Reviewing design
+		* [Status screen](https://invis.io/AVGRKKJ75KT#/294213577_Start_Webui_Design) 
+		* [Smaller menu version](https://invis.io/AVGRKKJ75KT#/294213563_Start_Webui_Design_Small_Menu)
+
+### Other
+
+- [PR with discussion on awesome-ipfs being a static site](https://github.com/ipfs/awesome-ipfs/pull/130)
+- http://arewedistributedyet.com interviews started, Oli wrote some thoughts on [what is needed to extend browsers with p2p protocols](https://github.com/ipfs-shipyard/arewedistributedyet/issues/19)
+- [Add a "desktop" friendly init profile to go-ipfs](https://github.com/ipfs/go-ipfs/issues/4989)
+
+## Action Items
+- Please take a read through the [Aegir findings](https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/51#issuecomment-385425256)
+- everyone to go over proposed WebUI designs and provide feedback (ASAP)
+- think about IPLD Explorer, provide thoughts at https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/11 (ok to do it later this week)

--- a/meeting-notes/2018/2018-05-08--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-05-08--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,72 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-05-08
+
+- **Lead:** @lidel
+- **Notetaker:** {no volunteer, @lidel did his best}
+- **Attendees:**
+  - @agata_krych
+  - @olizilla
+  - @alanshaw
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- WebUI updates
+- Lisbon Hack Week (who is coming? what should be the focus?)
+- Enabling DWeb exploration at Mozilla
+- Mid quarter OKR checkin
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Browsers
+
+- IPFS Companion
+	- Fixed websocket handshake being broken by Companion and released along with other stuff as [v2.2.2](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.2.2)
+	- Automated bundle builds for 'stable' and 'beta' channels, added CI smoke test for Windows dev
+	- Looking at [addressing webcrypto limitations in Chrome](https://github.com/ipfs-shipyard/ipfs-companion/issues/475)
+- Enabling DWeb exploration at Mozilla
+	- Internal discussion at Mozilla was initialized by @gozala (Thanks!)
+	- The focus so far is to plan work related to proper protocol handler, socket API and webrtc datachannels, expect updates at some point
+
+### New WebUI
+
+- Getting together WebUI 2.0 base
+	- Exploring how to Redux without the boilerplate
+	- Next: research and make decisions on create-react-app vs parcel, redux patterns
+- [Getting IPLD working in JS-IPFS](https://github.com/ipfs/js-ipfs-api/pull/755) so we can create an IPLD explorer that also works with JS-IPFS
+
+### Other
+
+- Adding test harness to peer-pad to avoid prod errors in fututre
+	- Overview: [Testing Peerpad with Puppeteer](https://www.youtube.com/watch?v=g0l738fq3C0)
+	- Next: trying to recreate the yarn build issue, as it seems significant if there are issues building new webui
+- PSA: Alan have taken on lead maintainer role for [js-ipfs](https://github.com/ipfs/js-ipfs), [js-ipfs-api](https://github.com/ipfs/js-ipfs-api) and [interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core/)
+
+## Action Items
+
+- All: think about IPLD Explorer, provide thoughts, sample screens, mockups at https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/11
+
+- All: fill mid-quarter OKR scores
+	> Following up, I want to ask you to spend 30 minutes this week scoring your OKRs on the [Q2 OKR spreadsheet](https://docs.google.com/spreadsheets/d/1xIhKROxFlsY9M9on37D5rkbSsm4YtjRQvG2unHScApA/edit#gid=755202447). For this exercise, I’m asking you to:
+	> - Do a score of your KRs on its current state (0 to 1 with regards to completion) - Mid-Q Actual Column
+	> - Do a score of your KRs on what you believe the degree of completion by the end of the Quarter (0 to 1) - Mid-Q Projection Column
+	> - Do a self-check on Priorities. See if the things you are working on are the most important ones, if they are not, explain to yourself why and check in if they are indeed more important that what is listed. If they happen to be more important, explain it to the team, if they are not, drop it in favor of the more important ones.

--- a/meeting-notes/2018/2018-05-14--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-05-14--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,44 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-05-14
+
+- **Lead:** @lidel
+- **Notetaker:** @olizilla 
+- **Attendees:**
+  - @lidel
+  - @hacdias
+  - @olizilla
+  - @alanshaw
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Kick-off discussion about formalizing a "GUI Team" (@lidel)
+- Overview of new-WebUI foundation project
+  - https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/51#issuecomment-388832540
+  - https://github.com/tableflip/ipfs-webui-cra
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+# Action Items
+
+- @all: Send IPLD Explorer UI ideas to Oli and Agata
+- @all: Define the options that should appear in the webui settings page. See https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/15

--- a/meeting-notes/2018/2018-05-21--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-05-21--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,72 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-05-21
+
+- **Lead:** @lidel
+- **Notetaker:** @alanshaw
+- **Attendees:**
+  - @lidel
+  - @alanshaw
+  - @kyledrake
+  - @hacdias
+  - @olizilla
+  - @gozala
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Update from convo with gozala
+- Brave news
+
+## Notes
+
+* IPFS Companion news
+    * New beta of Companion that preserves file names and supports sharing of multiple files
+        * https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.2.2.9320
+    * Bugs investigation related to uploads via Companion in firefox and chrome (out of memory, playing with streaming to mitigate that, and looking at ways we can provide visual feedback)
+* WebUI news
+    * Progress on new IPLD explorer page
+        * ![IPLD explorer page](https://usercontent.irccloud-cdn.com/file/TsppHg9u/Screenshot%202018-05-21%2016.04.47.png)
+    * UI components being built out using React Storybook
+        * Files components: https://github.com/ipfs-shipyard/ipfs-webui/pull/658#issuecomment-390351489
+* Firefox news
+    * Gozala is working on Firefox experiment (think prototype of actual WebExtension API) that will provide 'native' ipfs:// protocol handler
+        * https://github.com/Gozala/libdweb/
+    * @olizilla, @lidel and @gozala discussed priorities and challenges related to industry-wide conventions around origins and URIs:
+        * Aiming for ipfs:// as it does not go against origin conventions already present in browser vendors, and specifically to Firefox, does not require changes to sensitive parts of browser
+        * The dweb: may remain a redirect to ipfs:// for some time
+        * If we have case-insensitive CIDv1, then we can use it as-is in ipfs://<cid>
+* Brave news
+    * Bringing forwards the release date for the chromium based version
+    * **Canceled** bundling go-ipfs with muon version
+    * Want to bundle IPFS Companion with chromium based version
+
+
+## Action Items:
+
+* Gozala/libdweb
+    * Feedback on issues in https://github.com/Gozala/libdweb/
+    * Push for a useful default CID encoding for use as the host part of urls so we can integrate with browsers in this decade - https://github.com/ipfs/go-ipfs/issues/4143
+* It's h4ck week in Lisbon this week, aims:
+    * Companion upload improvements shipped to stable
+    * window.ipfs security perimeter and its UX defined
+    * Decision on details of creating WG/Teams
+* Brave
+    * Feedback to Brave team on other APIs or tweaks we might want to make a more seamless experience (for IPFS Companion bundled), that are less work than `registerProtocolHandler`

--- a/meeting-notes/2018/2018-05-29--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-05-29--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,55 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-05-29
+
+- **Lead:** @lidel
+- **Notetaker:** @olizilla
+- **Attendees:**
+  - @lidel
+  - @hacdias
+  - @olizilla
+  - @alanshaw
+  - @agata
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Post-Lisbon: discuss formalizing GUI team (project Leaders etc)
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Updates
+
+- [Circuit relaying](https://github.com/ipfs/js-ipfs/tree/master/examples/circuit-relaying) is coming to libp2p/js-ipfs. 
+  It should solve centralization/connectivity issues we currently experience in the browser land, but discovery needs to be added first.
+- Published v2.3.0 of Companion with upload and `window.ipfs` security improvements: https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.3.0
+
+### Action Items
+
+- @all: review the settings issue https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/15
+- @olizilla: go over invisions with @daviddias
+- @all: add yourself as a Lead Maintainer to projects you already maintain
+- @lidel @olizilla document release plans for Companion.
+- @agata deliver WebUI wireframes
+- @hacdias deliver WebUI file browser revamp.
+- @olizilla write up webui app store idea.
+- @alanshaw upadte ipfs-postmsg-proxy with new apis

--- a/meeting-notes/2018/2018-06-04--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-06-04--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,75 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-06-04
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+  - @lidel
+  - @agata
+  - @hacdias
+  - @olizilla
+  - @alanshaw
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Should we create separate waffle boards for GUI Team and in-web-browsers WG ? 
+    - js-* teams seems to be utilizing them quite nicely: https://github.com/ipfs/js-ipfs/blob/master/MGMT.md
+    - right now there is one huge board: https://waffle.io/ipfs/in-web-browsers
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Updates
+
+- @akrych
+  - Settings wireframe is ready for feedback: https://invis.io/AVGRKKJ75KT#/300639276_Settings_Webui_Wirefram
+  - Next: addressign feedback, planning next design tasks
+
+- @hacdias
+  - Been busy with uni work :)
+  - Next: get back to WebUI after exams end next week
+
+- @lidel
+    - Released small beta with some fixes for bugs from backlog
+    - Made a small poc that confirmed we can't normalize URIs in protocol handler from mozilla/libdweb (an open problem: how to solve this regression)
+    - Made some progress on getting a privileged (non-sandboxed) window.ipfs object work in ipfs-companion without need for any shared-secret. standard content script APIs wont work for internal page, but found possible workaround
+    - Next: paused other work and looked into ways we can address CORS false-positives (https://github.com/ipfs-shipyard/ipfs-companion/issues/436), as it broke some websites. Release beta + Stable  with the workaround/fix.
+
+- @alanshaw
+    -  Added ping to window.ipfs (https://github.com/ipfs-shipyard/ipfs-companion/pull/492)
+    -  Spent some time on sorting out the dag api (https://github.com/ipfs/interface-ipfs-core/issues/125)
+        -  dag.resolve shouldn't exist, but it's really useful
+        -  we need to improve API by dogfooding it, namely in IPLD Explorer in new WebUI
+    - Next:  get the proposal for DAG API accepted & implemented, holiday next week
+
+- @olizilla
+    - Tracked down the "already piped" bug in js-ipfs (https://github.com/libp2p/js-libp2p-switch/pull/262)
+    - Reviewed the rad Files screen in new WebUI made by @hacdias
+    - Learning about dag get vs dag resolve for the IPLD page, prototyping UIs and missing IPLD APIs that are needed for IPLD Explorer in new WebUI
+    - In brave news, together with @lidel figured out what we'd like to improve next in companion and what would be needed for brave
+
+## Action Items
+
+- @all: comment/provide feedback on https://invis.io/AVGRKKJ75KT#/300639276_Settings_Webui_Wireframe
+- @olizilla, @hacdias ++ go over comments in Invision, help Agata build the list of "whats next"
+- @all: comment on proposed _New UI for Backend Control_ in browser extension: https://github.com/ipfs-shipyard/ipfs-companion/issues/491

--- a/meeting-notes/2018/2018-06-11--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-06-11--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,62 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-06-11
+
+- **Lead:** @lidel
+- **Notetaker:** @lidel
+- **Attendees:**
+  - @lidel
+  - @hacdias
+  - @olizilla
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+- (holidays, so it will be brief sync)
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+Updates:
+- @lidel
+    - spent some time on revisiting how we inject window.ipfs. tl;dr: Chrome limitations still stand but I was able to improve fingerprinting situation on firefox a bit using firefox-only API for injecting contentScripts, PR: https://github.com/ipfs-shipyard/ipfs-companion/pull/495
+        - A digression: we may want to change approach to window.ipfs at some point to make it work more like navigator.permissions.query (solves fingerprinting and improves UX of asking multiple APIs via single dialog) but this requires either a wrapping lib  or a new webextension API.
+    - While doing that I noticed pain points related to browserify, and invested some time to work towards webpack-based build. Based on initial experimentation it is not only faster than browserify but plugin ecosystem will enable us to do vendor-based builds in programmatic way. 
+        - got the basic build working and ready for review: https://github.com/ipfs-shipyard/ipfs-companion/pull/498 (tl;dr its faster and produced bundles take less space)
+    - Next: review/merge PRs and go over github backlog, take a stab at backend switch UI in companion, and then switch back to libdweb endeavor (revisit protocol handler after recent changes in Firefox Nightly)
+- @hacdias
+    - afk due to exams
+    - Next: ace exams! work on webui (if time allows)
+- @olizilla
+    - got the explore page graph and internals refactor done
+        - PR: https://github.com/ipfs-shipyard/ipfs-webui/pull/672
+    - Next: focus on webui, particularly the loading and empty states for the files and explore pages
+- @akrych
+	- Sorry guys, did't make it :) from my side I made all designs on invision:
+		- https://invis.io/AVGRKKJ75KT#/302166384_IPLD_screen
+		- https://invis.io/AVGRKKJ75KT#/302167366_Peers_screen
+		- https://invis.io/AVGRKKJ75KT#/302169242_Settings_screen
+		- https://invis.io/AVGRKKJ75KT#/302173034_File_screen_-_rename_file
+		- https://invis.io/AVGRKKJ75KT#/302173033_File_screen_-_delete_file
+
+Action Items:
+- @all: review and comment on new designs in invision (links above)
+- @alan/@oli: review move to webpack https://github.com/ipfs-shipyard/ipfs-companion/pull/498
+- @lidel: review DAG explorer UI https://github.com/ipfs-shipyard/ipfs-webui/pull/672

--- a/meeting-notes/2018/2018-06-18--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-06-18--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,65 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-06-18
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+  - @lidel
+  - @agata_krych
+  - @alanshaw
+  - @hacdias
+  - @olizilla
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Updates
+
+- @olizilla
+    - busy on filecoin-explorer last week, demo going out soon
+    - Next: wrap up filecoin work, work on webui for the rest of the week (settings page, then addressing feedback for DAG Explorer)
+- @lidel
+    - removed browserify, finished our switch to webpack (including content scripts), the PR is merged: https://github.com/ipfs-shipyard/ipfs-companion/pull/498
+    - created poc for global ON/OFF switch:  https://github.com/ipfs-shipyard/ipfs-companion/pull/500
+    - Next: merge on/off PR, create a PR with backend selector (as noted in https://github.com/ipfs-shipyard/ipfs-companion/issues/491), then get back to libdweb PoCs
+- @alanshaw
+    - on holiday last week \o/
+    - Next: getting back to things today, providing feedback, clearing out inbox etc
+- @hacdias
+    - finished the delete prompt and the rename one is almost done
+    - Next: pass the last exam :-^-)
+- @agata_krych
+    - "too many projects, not enough agatas"
+    - To tame the chaos, new design work needs to be requested via https://github.com/protocol/design/issues
+    - Invision screens waiting for feedback:
+        - https://invis.io/AVGRKKJ75KT#/302166384_IPLD_screen
+        - https://invis.io/AVGRKKJ75KT#/302167366_Peers_screen
+        - https://invis.io/AVGRKKJ75KT#/302169242_Settings_screen
+        - https://invis.io/AVGRKKJ75KT#/302173034_File_screen_-_rename_file
+        - https://invis.io/AVGRKKJ75KT#/302173033_File_screen_-_delete_file
+    - Next: waiting for feedback or requests, will get back to webui/status page soon
+
+
+### Action Items
+
+- @all: review Invision screens (links above)

--- a/meeting-notes/2018/2018-06-25--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-06-25--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,85 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-06-25
+
+- **Lead:** @lidel
+  - **Notetaker:** @lidel
+- **Attendees:**
+  - @lidel
+  - @agatakrych
+  - @alanshaw
+  - @olizilla
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Diogo Silva joins In Web Browsers WG in Q3 \o/ 
+- Let's start thinking about OKRs for Q3 
+- Should WebUI Revamp PRs come with  translations?
+- Should we ship ON/OFF toggle asap?
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Updates
+
+- @lidel
+    - went over action items from last week, namely WebUI reviews (settings, dialogs etc)
+    - investigated bugs: beta channel updates in Firefox and Linkify issues on Slack/Twitter
+    - protoyped ways we could implement backend selector, but no PR yet
+    - invited Diogo to join in web browsers WG next quarter and provided him with an initial overview today
+    - Next: fix linkify, back to PR with backend selector, get back to libdweb, assist Diogo if any questions
+
+- @alanshaw
+    - working on status page
+        - porting bandwidth list from old PoC
+        - solving performance issues
+    - reviewing webui PRs
+
+- @olizilla
+    - busy with refactor and test the Filecoin Explorer
+    - settings page for the WebUI
+    - Next: loading states and visualising what's going on in ipfs when you start IPLD exploring unreachable CIDs
+
+- @hacdias
+    - finishing exams season \o/
+    - Next: finish the opened PRs and apply the components to the WebUI, fix some issues on the file browser
+
+- @agata
+    - busy with Berlin Dev Week stuff
+    - Next: get back to status page when free
+
+### Other
+
+- React components are developed inside of `revamp` branch of WebUI for now
+    - When mature, we will extract them into a reusable library
+- Should WebUI Revamp PRs come with  translations?
+    - Yes, its on the radar (currently opened PRs will not be enforced)
+- Should we ship ON/OFF toggle asap?
+    - Yes (there is a small rendering issue on Mac, will look into it)
+
+### Action Items
+
+- @all
+    - review WebUI PRs:
+        -   status page
+        -   settings page  (second iteration)
+    - think about what to focus on in Q3 and how to communitate it using OKRs

--- a/meeting-notes/2018/2018-07-02--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-07-02--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,82 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-07-02
+
+- **Lead:** @olizilla 
+- **Notetaker:** @lidel
+- **Attendees:**
+  - @lidel
+  - @olizilla
+  - @fsdiogo
+  - @hacdias
+
+## Goals
+
+- Our GUI apps expose core IPFS features in a robust, accessible and intuitive form
+- Browser developers are committed to addressing requirements of the distributed web
+- Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Bootstrap discussion about Q3 OKRs: https://github.com/ipfs/in-web-browsers/issues/85
+  - Do we plan together & split after?
+  - Hackpad with draft ideas fro Q3 2018 OKRs: <del>https://hackmd.io/63Ot04yETI6_Lmpa8sjw5A?view</del> (moved to [IPFS 2018 Q3 OKRs](https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/edit?usp=sharing))
+- Berlin Dev Sessions
+- DWEB 2018 
+- Set agenda before lunch on Mondays so we have time to think about them and ask better questions
+    - Should we do it via new issue each week?
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Updates
+- @fsdiogo
+    - catching up with Companion and WebUI, onboarding, thinking about KRs
+    - **Next:** grab something bigger to work on
+
+- @lidel 
+    - Fixed Linkify experiment to work with  Slack and Twitter, made it more robust by rate limiting and fixing race-conditions in dynamic JS apps that mutate DOM: https://github.com/ipfs-shipyard/ipfs-companion/pull/504
+    - Created a workaround for Companion's uploads being broken due to 'invalid Read on closed Body' bug in HTTP API (go-ipfs): https://github.com/ipfs-shipyard/ipfs-companion/pull/509 more info about actual bug in go-ipfs can be found at https://github.com/ipfs/go-ipfs/issues/5168 (for now we only fix uploads done via browser action in browser extension, but it is possible to fix it globally for all websites using js-ipfs-api – should we?)
+    - Added a way to opt-out from gateway redirect for a single request via URL hint:  https://github.com/ipfs-shipyard/ipfs-companion/pull/505
+    - Released above to Beta: https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.4.0.10120
+    - Researched WebRTC issues we had in past, as Mozilla asked us to provide some examples that make browser unstable. More on this next week.
+    - **Next:** Work on Q3 OKRs, Prepare for Berlin, libdweb is time allows
+
+- @hacdias
+    - work on WebUI's File Browser and reviews
+        - selecting and downloading multiple files
+        - pretty prompts for deleting and renaming
+    - **Next:** upload files, folders & by IPFS Path, maybe drag&drop
+
+- @olizilla
+    - "make the GUI team" a thing: https://github.com/ipfs/ipfs-gui
+    - slide deck with feedback how we're doing on the GUIs: https://ipfs.io/ipfs/QmUjfm9heNhB4qZ2fDj35Q7CiycfFMxigP3hnWWXWiKouV/
+    - solving remaining issues with WebUI's Settings Page
+        - feedback welcome on: https://github.com/ipfs-shipyard/ipfs-webui/pull/690
+    - IPLD start page: https://github.com/ipfs-shipyard/ipfs-webui/pull/690
+    - debugging of windows CI test fails or js-ipfs
+    - **Next:** getting Settings and IPLD Pages merged, IPLD Explore improvements (dealing with large buffers)
+
+- In Other News
+    - Agata is busy with other PL work, won't be able to help GUI team in Q3
+        - Looking for way to adapt to this change (hiring etc)
+
+### Action Items
+- @all feedback welcome on:
+    - https://github.com/ipfs-shipyard/ipfs-webui/pull/690
+- @all **think about (O)KR ideas for Q3 and add them to hackpad**
+    - <del>https://hackmd.io/63Ot04yETI6_Lmpa8sjw5A?view</del> (moved to [IPFS 2018 Q3 OKRs](https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/edit?usp=sharing))
+    - We will have call later this week to go over proposed ideas and refine them into OKR draft

--- a/meeting-notes/2018/2018-07-16--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-07-16--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,143 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-07-16
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+  - @lidel
+  - @fsdiogo
+  - @olizilla
+  - @hacdias
+  - @alanshaw
+
+## Goals
+
+- GUI
+    - Core IPFS features are intuitve and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+- Web Browsers 
+    - Browser developers are committed to addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Create a developer ecosystem around window.ipfs apps
+
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Finalize OKRs for Q3:
+    - we may want to schedule separate ~1h call for this on Tuesday
+        - every KR should have an owner, we may split/merge things depending on who gets what
+        - we should a list of what is needed from other WG' ready for OKR review on 18th 
+- How should we handle CIDv0 in browser extension?
+    -  converting to CIDv1 is not enough with current nodes, so displaying option to copy cidv1b32 will frustrate users as things won't work
+    -  should we handle CIDv0 as a special case and convert root to CIDv1 (ipfs.files.chcid) ?
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+### Updates
+
+- @lidel
+    - Worked on OKRs for Q3, published draft in the  `wb` sheet: [Web Browsers OKRs](https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/edit?ts=5b28e2d5#gid=755202447)
+    - Restored gateway redirect for CORS XHRs in Firefox:    
+      https://github.com/ipfs-shipyard/ipfs-companion/pull/511
+      - This shipped to stable channel just in time for https://ournetworks.ca/livestream/ :-))
+    - Filled for a visa to attend DWEB 2018 (it takes tiiiime)
+    - Fixed and released a bunch of improvements to stable channel.    
+      See Release Notes for [v2.4.1](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.4.1) and [v2.4.2](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.4.2)
+    - Had a busy week in Berlin
+        - Lightning Talk about Web Browsers WG:  https://ipfs.io/ipfs/QmYh7rfHj8sBL7f6ssEXWssuzjHUwyqHyPFy7NcNUFKs1Y/#0
+        - Base32 Strike Force was born: https://github.com/ipfs/ipfs/issues/337
+            - Created tasks to support [CID as a Subdomain](https://github.com/ipfs/in-web-browsers/issues/89) 
+            - Drafted steps for [Companion support for Base32 CIDv1](https://github.com/ipfs-shipyard/ipfs-companion/issues/527)
+    - Discovered some issues with window.ipfs.files.cp (need some feedback):
+      https://github.com/ipfs-shipyard/ipfs-companion/issues/530
+    - Fixed linkify experiment on hackmd (not merged yet):
+      https://github.com/ipfs-shipyard/ipfs-companion/pull/528
+    - Fixed pubsub with js-ipfs via window.ipfs (not merged yet):
+      https://github.com/ipfs-shipyard/ipfs-companion/pull/529
+    - Discovered an issue with libdweb in latest Firefox Nightly:
+      https://github.com/mozilla/libdweb/issues/16 (fixed)
+    - Next:
+        - Release beta with recent PRs
+        - AFK on Wednesday (VISA interview at US embassy) until evening call 
+        - Create IPFS demo branch with the latest version of Protocol handler API:
+          https://github.com/mozilla/libdweb/issues/2 
+
+- @fsdiogo
+    - Done:
+        - Worked on revamping the peers page on the WebUI
+            - Added the world map with coordinates to show peers
+            - Added the peers table
+        - Developers Meeting in Berlin
+        - Updated the peers table to use react-virtualized
+    - Next:
+        - Add dynamic location to the map & table
+
+- @hacdias
+    - Done:
+        - Kept working on Files Browser page on WebUI
+            - [Add a new folder](https://github.com/ipfs-shipyard/ipfs-webui/pull/721)
+            - [Truncate text on small screens + a new tooltip](https://github.com/ipfs-shipyard/ipfs-webui/pull/717)
+            - [Use pull streams](https://github.com/ipfs-shipyard/ipfs-webui/pull/719)
+            - [Now File Browser works with non-ascii characters](https://github.com/ipfs-shipyard/ipfs-webui/pull/716)
+            - [Some Tweaks](https://github.com/ipfs-shipyard/ipfs-webui/pull/723)
+        - Finally managed to continue the Awesome IPFS static website
+            - [The Pull Request](https://github.com/ipfs/awesome-ipfs/pull/130)
+            - [Try it out!](https://ipfs.io/ipfs/QmNcn9s3jV6QZ6eixgwmm6gagFGmKaUM5ftWoTN3qwa5Ba/)
+    - Next:
+        - Waiting for reviews on the tweaks PR.
+        - Hopefully finish and merge the Awesome IPFS.
+    - About the OKRs and Q3 (don't have permission to edit the file):
+        - WebUI on Desktop!
+        - I don't know a lot about IPLD and how everything works together, but I'd like to take a shot at **IPLD explorer supports 3 exotic formats (ipld-git, ipld-btc, ipld-eth-*)** OKR.
+        - Can help with **Web UI pages are published as standalone webapps that can be linked to from new apps (e.g. filecoin explorer)**.
+
+- @alanshaw
+    - Done:
+        - Berlin
+            - base32 discussion (see update from @lidel), and consequence: assigned myself responsibility for js-ipfs base32
+        - Hacked on https://github.com/ipfs-shipyard/ipfs-companion/pull/520 with @lidel
+    - Next:
+        - Finish peer location bundle for WebUI and add to status page
+
+- @olizilla
+  - Done:
+    - Drafted OKRs for GUI team https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/edit?ts=5b489369#gid=1841105909
+    - Gave the GUI Team update at Berlin dev conf https://ipfs.io/ipfs/QmTj8em6XKSfNLX6Xo6eKfp3K7sGpgj8hSwtck7p3jij98/
+    - IPLD start page and large list fixes https://github.com/ipfs-shipyard/ipfs-webui/pull/690
+    - Webui nav toggle
+  - Next:
+    - Present GUI OKRs
+    - Webui status page
+    - Extract ipld explorer as standalone webapp.
+
+### Agenda
+
+#### Finalize OKRs for Q3
+
+We decided to have a <1h call and go over all OKRs, set priorities and leaders together.
+     
+#### How should we handle CIDv0 in browser extension?
+
+We decided there will be no CIDv0-specific UI items for now  apart from providing conversion UI in native protocol handler, which is something we can't avoid.
+
+### Action Items
+- @all: keep doing good work :-)

--- a/meeting-notes/2018/2018-07-23--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-07-23--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,106 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-07-23
+
+- **Lead:** @lidel
+- **Notetaker:** @lidel
+- **Attendees:**
+  - @fsdiogo
+  - @lidel
+  - @alanshaw
+  - @hacdias
+  - @olizilla
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Plan/sync DWEB Summit 2018 talks (@lidel, @alanshaw)
+- What's missing in the WebUI status page? (@fsdiogo, @olizilla)
+- {add anything you want to discuss / show}
+
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+
+### Updates
+
+- @alanshaw
+    - Done
+        - Finished peer locations bundle ([#702](https://github.com/ipfs-shipyard/ipfs-webui/pull/702))
+        - Working on peer country chart ([#734](https://github.com/ipfs-shipyard/ipfs-webui/pull/734))
+    - Blocked
+        - `null`
+    - Next
+        - Pie charts for up/down speed and disk quota
+
+- @fsdiogo
+    - Done:
+        - Integrated peer locations bundle
+            - Added peers locations to the world map
+            - Added the flags to the peers table
+        - Shipped the revamped peers page
+    - Next:
+        - File sharing flow
+
+- @hacdias
+    - Done:
+        - Kept working on File Browser page
+        - Thought about caching and started implementing it as a proof-of-concept
+        - Awesome IPFS published (https://awesome.ipfs.io)
+    - Next:
+        - Find a way to make reactX functions to be called on time (https://github.com/ipfs-shipyard/ipfs-webui/pull/736) otherwise we won't have a responsive WebUI.
+
+
+- @lidel
+    - Done:
+        - Added streaming and basic error handling to libdweb's ipfs:// ([wip PR](https://github.com/ipfs-shipyard/ipfs-companion/pull/533))
+        - Added support for CID in subdomains to [is-ipfs](https://github.com/ipfs/is-ipfs) and Companion ([PR](https://github.com/ipfs-shipyard/ipfs-companion/pull/537))
+        - window.ipfs.files.cp|mv scoping fix [PR](https://github.com/ipfs-shipyard/ipfs-companion/pull/531)
+        - Created initial draft of "IPFS Addressing in Web Browsers" Memo ([PR](https://github.com/ipfs/in-web-browsers/pull/92))
+    - Next:
+        - Release Beta and Stable before Dweb Summit
+        - Work on presentations for Dweb Summit and PL Day
+        - Write up feedback on ipfs:// (edge cases such as video tag) 
+
+### Agenda
+
+- Discuss next work focus for @fsdiogo
+    - Sharing seems like a good pick, can be worked in a fashion that is mostly decoupled from Files screen.
+- Should we rename webui `revamp` branch to `master` and `master` to `legacy`?
+    - Ok, but need to finish status page and have NPM package ready to get buy in from go-ipfs and js-ipfs to ship ship ship
+
+### Action Items
+
+- @fsdiogo will look into "Sharing via IPFS" flow, design and screens
+    - https://github.com/ipfs-shipyard/pm-ipfs-gui/issues/34
+- @lidel, @alanshaw, @daviddias: met tomorrow and discuss Dweb Summit talks

--- a/meeting-notes/2018/2018-07-30--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-07-30--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,106 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-07-30
+
+- **Lead:** {?}
+- **Notetaker:** {?}
+- **Attendees:**
+  - @fsdiogo
+  - @hacdias
+  - @alanshaw
+  
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- None (DwebSummittng)
+
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+
+### Updates
+
+- @lidel (my flight is already delayed, so I probably won't be able to join the sync)
+    - Done: 
+        - Created a summary / meta-issue for [Mirroring Web to IPFS](https://github.com/ipfs/in-web-browsers/issues/94)
+        - Released ipfs-companion [v2.4.3](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.4.3)
+        - Looked into was we can preload window.ipfs – [issue](https://github.com/ipfs-shipyard/ipfs-companion/issues/546)
+        - General QA before dweb (eg. [issue](https://github.com/ipfs-shipyard/ipfs-companion/issues/542) with pinning IPNS)
+        - Slide Deck / Demos for Dweb Lightning Talk and Lab Day 
+    - Next: 
+        - Fly to SF, busy week at Dweb Summit! 
+
+- @fsdiogo
+    - Done:
+        - IPFS Share Files
+            - https://github.com/ipfs-shipyard/ipfs-share-files
+            - Bootstrapped the app
+            - Created the main components
+        - js.ipfs.io
+            - Reviewed lots of PRs and got some features and improvements done
+    - Next:
+        - Implement the files upload 
+
+- @hacdias
+    - Done:
+        - Worked on Context Menu: https://github.com/ipfs-shipyard/ipfs-webui/pull/720
+        - Worked on File Status: https://github.com/ipfs-shipyard/ipfs-webui/pull/718
+        - Tweaks and fixes on WebUI and File Browser:
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/718
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/739
+    - Next:
+        - Finish Files page. It's almoooost there (what's missing: https://github.com/ipfs-shipyard/ipfs-webui/issues/704)
+
+- @alanshaw
+    - Done:
+        - Not worked on webui this week, concentrated on release js-ipfs 0.31 with content preloading in time for dweb summit
+    - Next:
+        - Presenting at DWeb Summit
+
+- @olizilla
+    - Done: 
+      - IPLD Explorer extracted to standalone app
+      - Has multi-fallback window.ipfs -> js-ipfs-api -> js-ipfs
+      - proto.school design and implement 
+
+- {?}
+
+
+### Notes from Agenda
+
+- {?}
+
+### Action Items
+
+- {?}

--- a/meeting-notes/2018/2018-08-06--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-08-06--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,126 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-08-06
+
+- **Lead:** @lidel
+- **Notetaker:** {?}
+- **Attendees:**
+    - @hacdias
+    - @lidel
+    - {add youself}
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- [@fsdiogo] I'll be on vacations until August 20th so I won't attend this sync nor next week's 
+- [@fsdiogo] If you want to check the current status of the IPFS Share Files app:
+    - See the video for a preview
+        - https://usercontent.irccloud-cdn.com/file/eGJos9w5/up.mov
+    - Checkout the master branch and run the app locally
+        - https://github.com/ipfs-shipyard/ipfs-share-files
+- [@lidel] Mid Quarter OKR Review and Resync
+  We will do the review call on 13th so this week is a good time to prepare in async mode.
+  I am asking everyone with [KR assigned](https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/#gid=755202447) to take a moment and:
+    - Do a score of your KRs on its current state (0 to 1 with regards to completion) - [Mid-Q Actual Column](https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/#gid=755202447)
+    - Do a score of your KRs on what you believe the degree of completion by the end of the Quarter (0 to 1) - [Mid-Q Projection Column](https://docs.google.com/spreadsheets/d/19vjigg4locq4fO6JXyobS2yTx-k-fSzlFM5ngZDPDbQ/#gid=755202447)
+    - Do a self-check on Priorities
+- {add anything you want to discuss / show}
+- [@hacdias] From the 11th to the 16th I won't be available. And until the end of the month I might be a bit less active, but still here.
+
+
+## Notes
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+
+### Updates
+
+- @lidel 
+    - Done: 
+        - Attending Dweb Summit and Lab Day, various discussions and demos
+        - Gave sprinty 5min talk on IPFS Companion at DwebSummit 
+        - Implemented IPNS support in `libdweb` branch of Companion
+        - One-liner build pipeline for `libdweb` branch 
+        - Gave a quick demo of IPNS working with mozilla/libdweb at Lab Day on friday 
+    - Next:
+        - Convert a notes from Dweb Summit and Lab Day into actionable issues in respective repos
+        - Go over the backlog from last week
+
+- @fsdiogo
+    - Done:
+        - Implemented files upload
+            - Add one or multiple files and see progress info
+            - Get shareable link to access the added files
+        - Added responsiveness
+    - Next:
+        - Vacations \o/
+
+- @hacdias
+    - Done:
+        - fixed config.get on js-ipfs-api
+        - New IPFS Desktop release (0.5.0) with some bug fixes and new go ipfs version
+        - WebUI now has loadable components for each page
+        - Enabled the share functionality on WebUI
+        - Cached peers locations for 1 week
+        - Some File Browser tweaks: https://github.com/ipfs-shipyard/ipfs-webui/pull/741
+        - File Browser context menu
+        - Worked on https://github.com/ipfs-shipyard/ipfs-webui/pull/715
+    - Next:
+        - Try out js-ipfs on IPFS Desktop 😁
+
+### Notes from Agenda
+
+- DWeb Summit & Lab Day in San Francisco
+  - DWeb Summit
+    - An 1h  block of IPFS Lightning Talks from first day of DWeb Summit 2018 starts at https://youtu.be/eO6pYYWZBs8?t=545
+    - There is one 6h+ video per every room  per every day: https://www.youtube.com/channel/UCFa_X02QhJnP0FNpFAKyRRg/videos
+      - list of talks and room info is at https://decentralizedwebsummit2018.sched.com, so it may be possible to find other IPFS talks that way
+  - Lab Day was also recorded, videos will be published at https://www.youtube.com/c/IPFS-dweb/videos when ready
+- New APIs (libdweb)
+  - current approach is to design and smoke test new APIs in Firefox, IPFS and others demonstrate value added by those APIs by using them in our extensions, then other vendors have 1) API spec ready to implement 2) set of extensions that already consume those API
+  - @lidel created short doc on running Companion with mozilla/libdweb: https://github.com/ipfs-shipyard/ipfs-companion/blob/libdweb/docs/libdweb.md
+    - initial run of `npm run libdweb` takes a bit time (it downloads nightly and libdweb), but then its just `npm run libdweb:firefox`  to start it next time
+  - Local Discovery in Web Browsers    
+    We want to make js-ipfs compliant with mDNS implementation that follow DNS-SD, so we can use [mDNS API from mozilla/libdweb](https://github.com/mozilla/libdweb/issues/7) and get LAN discovery \o/
+      - For background, see ongoing discussion Future of mDNS discovery in IPFS:
+        - https://github.com/libp2p/libp2p/issues/28
+        - https://github.com/libp2p/specs/pull/80
+  - libp2p, mdns and TCP Socket API
+    - @alanshaw noted we can inject custom configuration for libp2p when starting js-ipfs, which makes webext-only mdns and tcp transports much easier to ship
+- IPFS Desktop
+  - DWeb people been asking about IPFS Desktop app, we will probably focus on it as soon WebUI is in 'shippable' state (potential OKR for Q4)
+  - Release notes will have a note about which go-ipfs version is shipped with it
+  - At some point in future we will be looking into making it possible to switch to node-based js-ipfs as an alternative to  go-ipfs
+
+
+### Action Items
+
+- {?}

--- a/meeting-notes/2018/2018-08-20--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-08-20--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,116 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-08-20
+
+- **Lead:** @lidel
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @fsdiogo
+    - @alanshaw
+    - @hacdias
+    - @olizilla
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- @lidel, @olizilla: [Mid-Quarter OKR Scoring for Q3 2018](https://github.com/ipfs/in-web-browsers/issues/101)
+
+## Notes
+
+### Updates
+
+_Added in async mode before IRC sync_
+
+- @lidel
+    - **Two weeks ago** (everyone else was afk so we had no sync):
+        - Went over backlog and notes from Dweb/LabDay, created issues in various repos
+            - Highlight:  filled SVG/WEBM/ContentType issues with mozilla/libdweb, most got addressed by @Gozala already :-)
+        - Started work on re-using [ipfs-http-response](https://github.com/ipfs/js-ipfs-http-response) in ipfs-companion, so we have the same directory listing and content-type heuristics in js-ipfs, service worker gateway and ipfs-companion
+            - Blocker: [missing CIDv1 support](https://github.com/ipfs/js-ipfs-http-response/issues/8), started working on PR
+            - Identified some missing apis, missing/spotty support for hamd-sharding: looking into ways to address that in generic and reusable way that works today
+        - Switched libdweb branch to `async` handler (https://github.com/mozilla/libdweb/pull/59), which enabled us to set contentType based on first 512 bytes of received payload. Issues with webm and svg are solved, but use in `src` attribute works only within same origin/protocol:
+            -  **cross-origin**: assets within the same protocol but under different root CIDs do not load: https://github.com/mozilla/libdweb/issues/55
+            -  cross-protocol: `ipns://` page loading assets from `ipfs://` does not work: https://github.com/mozilla/libdweb/issues/52
+    - **Last week**:
+        - companion+libdweb
+            - Switched to latest libdweb
+                - Cross-origin assets within the same protocol now load fine, demo: `ipfs://bafkreihosso7nxtyhjtpvjmrdoflyup6ex6b2xgzezibavuonobt2l4dai`
+            - Looked into `ipns://tr.wikipedia-on-ipfs.org` issues with with embedded js-ipfs node
+                - right now fails on deep links due to sharding: https://github.com/ipfs/js-ipfs/issues/1279#issuecomment-413307589
+        - http://arewedistributedyet.com
+            - Moved under vendor-agnostic org (following plan from [issue 25](https://github.com/arewedistributedyet/arewedistributedyet/issues/25#issuecomment-411730739))
+            - CI does not work after the move, handed it over to @VictorBjelkholm, tracked [here](https://github.com/ipfs/testing/issues/126)
+            - In an effort to get [this](https://github.com/arewedistributedyet/arewedistributedyet/issues/23) off the ground opened issue for changing WHATWG HTML Spec to include DWeb protocols on the "safelist": https://github.com/whatwg/html/issues/3935
+                - [This](https://github.com/arewedistributedyet/arewedistributedyet/issues/23#issuecomment-413881896) comment describes how protocol "safelist" support looks like in Firefox, Chrome and Brave.
+        - Identified and reported a bug: [ipfs.files.add with {cidVersion: 1} returns CID of an empty file](https://github.com/ipfs/js-ipfs/issues/1518)
+    - Next:
+        - Add WebExtension context support to [ipfs-redux-bundle](https://github.com/ipfs-shipyard/ipfs-redux-bundle) and see identify any blockers for bundling WebUI with Companion
+        - Create PoC [dnslink support with X-Ipfs-Path](https://github.com/ipfs-shipyard/ipfs-companion/issues/548) (in effort to have dnslink enabled by default in stable channel without waiting for DNS TXT lookup API)
+
+- @hacdias (this includes the previous week)
+    - Got better from the allergy!
+    - Worked on JS-IPFS and external APIs support for IPFS Desktop (https://github.com/ipfs-shipyard/ipfs-desktop/pull/651)
+    - Working on WebUI: Files Polishing: https://github.com/ipfs-shipyard/ipfs-webui/issues/748
+
+- @fsdiogo
+    - Done:
+        - Vacations
+    - Next:
+        - Continue the work on ipfs-share-files
+
+- @alanshaw
+  - Done:
+    - Initial working version of discovery and transport using libdweb: https://youtu.be/LDHFqwC8Syg
+    - Added mid-quarter review https://github.com/ipfs/ipfs-gui/issues/63#issuecomment-413509702
+  - Next:
+    - Begin work towards base32 CIDs in earnest
+
+### Notes from Sync
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+- Discussed [ipfs-shipyard/ipfs-share-files](https://github.com/ipfs-shipyard/ipfs-share-files) for some time
+    - [Work in progress demo video](https://usercontent.irccloud-cdn.com/file/eGJos9w5/up.mov)
+    - We want to plug it into WebUI for sharing feature and embedd it into ipfs-companion to replace current Quick Upload screen
+    - "Download directory tree as `.tar.gz`" feature can be done via HTTP API: `curl https://ipfs.io/api/v0/get?arg=/ipfs/QmRAJM5ByzuKKpzKKisGDwBPHzYqMvVrYC2PcVhkMnP3gd&archive=true&compress=true > archive.tar.gz`
+        - We need to see how to handle this in context of embedded js-ipfs in browser (no local HTTP API)
+    - We want to be able to pass a list of CIDs via URL to enable use case where user selects multiple files in WebUI and clicks "share"
+- Discussed 3 step onboarding flows for webui / companion / desktop as another nice-to-have priority before Q3 ends
+    - some 'landing page' prior art/discussions: https://github.com/ipfs-shipyard/ipfs-companion/issues/324, https://github.com/ipfs/ipfs-gui/issues/27
+- Discussed [User testing plan for webui / companion / desktop](https://github.com/ipfs/ipfs-gui/issues/62)
+    - webui will go first, when initial version of revamp branch is released and shipped with companion/desktop we will unblock them to follow 
+
+
+### Action Items
+
+- @all with a KR for Q3:
+    - Do a score of your KRs on [Mid-Quarter OKR Scoring for Q3 2018](https://github.com/ipfs/in-web-browsers/issues/101)
+- @olizilla, @fsdiogo + interested parties will have a call about [ipfs-shipyard/ipfs-share-files](https://github.com/ipfs-shipyard/ipfs-share-files) at 2018-08-21 10:00AM GMT – link will be posted on IRC

--- a/meeting-notes/2018/2018-08-28--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-08-28--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,105 @@
+# GUI & In Web Browsers Weekly IRC Sync 2018-08-28
+
+- **Lead:** @lidel
+- **Notetaker:** olizilla
+- **Attendees:**
+    - @hacdias
+    - @fsdiogo
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Lets try Zoom Call!
+- PSA from @lgierth: CFP for chaos communication congress will start sometime soon
+
+## Notes
+
+### Team Updates
+
+- @lidel
+    - Done:
+        - Enable DNSLink by default in IPFS Companion: https://github.com/ipfs-shipyard/ipfs-companion/pull/558
+            - Thoughts?
+        - Brave discussion moved to a new repository in which and I wrote a summary that includes recent developments and started research towards current bundling conventions: https://github.com/brave/brave-browser/issues/819#issuecomment-415792868
+  - Next:
+      - Merge things and release new Companion Beta
+      - Check/addifmissing X-Ipfs-Path to js-ipfs gw
+      - Research and add some notes on Translations: https://github.com/ipfs/ipfs-gui/issues/50
+
+- @fsdiogo
+    - Done:
+        - Polished the upload flow
+        - Add flow
+        - Download flow
+    - Next:
+        - Finish download flow and quirks
+        - Ship IPFS Share Files
+
+- @hacdias
+    - Done:
+        - Charts for Status Page
+        - Merged the new Welcome page of WebUI (w/ @olizilla)
+        - Files navigation through arrow keys and some shortcuts
+        - Started working on Status Page: https://github.com/ipfs-shipyard/ipfs-webui/pull/766
+        - Started working on js-ipfs support for Desktop: https://github.com/ipfs-shipyard/ipfs-desktop/pull/651
+    - Next:
+
+- @alanshaw
+    - Done
+        - Fixed issue with `files.add --cid-version=1` [#1518](https://github.com/ipfs/js-ipfs/issues/1518)
+        - Upgraded the [IPLD explorer CLI tool](https://www.npmjs.com/package/ipld-explorer-cli) to use IPLD directly and resolve all sorts of node types. Also now works with js-ipfs daemon \o/!!!!
+        - Made progress investigating areas of the API that will be affected by adding a `--cid-base` option
+    - Next
+        - Continue base32 CID work [#1440](https://github.com/ipfs/js-ipfs/issues/1440)
+
+- @olizilla
+    - Done
+      - Fixed issue with ipld explorer not showing dag-pb with cid v1 address
+      - Fixed issue where you couldn't path into unamed dag-pb links
+      - Interviews for Community Engineer and Community Manager roles
+    - Next
+      - Reuse ipld explorer from webui
+      - Add i18n plumbing to webui
+
+### Discussions from <del>IRC</del> video call
+
+_Extracted from the meetings irc logs in #in-web-browsers_
+
+- We tested syncing over video call
+  - Everyone picks one item from updates and gives a quick demo followed by short discussion/Q&A
+  - Worked quite well, we will try again next week and think about recording as we get more familiar with the formula
+
+### Action Items
+
+- @all post thoughts or :+1 for [PR to enable DNSLink by default in Companion](https://github.com/ipfs-shipyard/ipfs-companion/pull/558)
+- @all read/contribute to the [plan for Translations across our GUI apps](https://github.com/ipfs/ipfs-gui/issues/50)

--- a/meeting-notes/2018/2018-09-04--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-09-04--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,120 @@
+# GUI & In Web Browsers Weekly Sync 2018-09-04
+
+- **Lead:** @lidel
+- **Notetaker:** @olizilla
+- **Attendees:**
+    - @hacdias
+    - @fsdiogo
+    - @lidel
+    - @olizilla 
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Lets try video call once again! (post link on irc)
+- @lidel: Translation Project
+    - moving to Transifex?
+    - how to handle i18next translations? (https://github.com/ipfs-shipyard/ipfs-webui/pull/772#issuecomment-418106980)
+- @hacdias: new hour for our sync
+- {?}
+
+## Notes
+
+### Team Updates
+
+- @lidel
+    - Done:
+        - [Researched and added some notes on crowdsourcing translations of our GUI apps](https://github.com/ipfs/ipfs-gui/issues/50)
+        - [Released IPFS Companion v2.4.4.10960 (Beta)](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.4.4.10960)
+            - Simplified language around DNSLink and enabled it by default in best-effort mode
+        - [Created a small test suite for checking if there are any known regressions at our public gateway](https://github.com/ipfs/infrastructure/pull/430)
+        - [PR with a fix for 'invalid Read on closed Body' in files.add under Chrome](https://github.com/ipfs-shipyard/ipfs-companion/pull/562)
+        - [PR for js-ipfs to add  `X-Ipfs-Path`, `Etag`, `Cache-Control`, `Suborigin` headers](https://github.com/ipfs/js-ipfs/pull/1537)
+  - Next:
+      - Release of IPFS Companion (Stable)
+      - Move companion to Transifex, create PoC CI setup
+      - Go over pending PRs
+
+- @hacdias
+    - Done:
+        - WebUI: [Finished the Status Page](https://github.com/ipfs-shipyard/ipfs-webui/pull/766)
+        - WebUI: [Simplified the file adding process (props to @lidel)](https://github.com/ipfs-shipyard/ipfs-webui/pull/769)
+        - WebUI: [Started working on i18n](https://github.com/ipfs-shipyard/ipfs-webui/pull/772)
+        - Desktop: [Remove Pinning and Add By Path (not merged yet)](https://github.com/ipfs-shipyard/ipfs-desktop/pull/655)
+    - Next:
+        - Integrate file-share-app with WebUI (w/ @fsdiogo)
+        - Finish i18n for WebUI
+        - Translate Web UI to PT (?)
+        - Expand graphs on status page
+
+- @fsdiogo
+    - Done:
+        - Finished download flow
+        - Refactored share link logic to lower its workload 
+        - Added loading component when fetching the file tree
+        - [Opened an issue in ipfs/infrastructure to create the share.ipfs.io domain](https://github.com/ipfs/infrastructure/issues/429)
+    - Next:
+        - Deploy IPFS Share Files
+        - Work on the landing pages for Companion
+
+- @olizilla
+  - Done:
+    - re-use ipld explorer as git submodule
+    - wip on re-use as a module (create module and webapp in same project)
+  - Next:
+    - webui node connection provider info
+    - [handle ipfs connection errors](https://github.com/ipfs-shipyard/ipfs-webui/issues/773)
+    - [publish webui to webui.ipfs.io](https://github.com/ipfs-shipyard/ipfs-webui/issues/775)
+    - Decide on i18n format.
+
+### Discussion Highlights
+
+#### Notes about i18n
+
+Background: https://github.com/ipfs/ipfs-gui/issues/50
+
+- i18next
+    - Can also support ICU format (https://react.i18next.com/misc/using-with-icu-format)
+    - **Pros**
+        - Easy to use.
+    - **Cons**
+        - Not supported on transifex without a third-party plugin.
+- React Intl
+    - **Pros**
+        - Maybe more future proof
+        - Supported on transifex
+    - **Cons**
+        - Is it activelly maintained (https://github.com/yahoo/react-intl/issues/1160)?
+        - Default props have to go in the component calls directly??? Like `<FormattedMessage id='key' defaultMessage='Hello' />` (there might be workarounds)
+        - Too many components

--- a/meeting-notes/2018/2018-09-10--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-09-10--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,126 @@
+# GUI & In Web Browsers Weekly Sync 2018-09-10
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @hacdias
+    - @olizilla
+    - @alanshaw
+    - @fsdiogo
+    - @lidel
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- What is missing for "having WebUI CID for PR against go-ipfs"? :-)
+- Q4 Planning is almost here. 
+    - The various calls will take place Sept 24-28. 
+    - Still time, but we should start thinking about OKRs for Q4. 
+- olizilla: Let's do the sync call (with rad demos) on Wednesdays as of next week.
+
+## Notes
+
+### Team Updates
+
+- @lidel
+    - Last week:
+        - Various PR reviews
+            - Really excited about [js-ipfs-api: add support for chunked uploads](https://github.com/ipfs/js-ipfs-api/pull/851) as a way of solving multiple issues with uploads of huge files over HTTP API.
+        - [Small progress with bundling go-ipfs with Brave](https://github.com/brave/brave-browser/issues/819#issuecomment-418713997)
+        - [Shipped Translation Project for IPFS GUIs](https://github.com/ipfs/ipfs-gui/issues/50)
+            - Moved js.ipfs.io, WebUI and Companion to Transifex:
+              https://www.transifex.com/ipfs/public/
+              - [Set up automatic sync of source files](https://github.com/ipfs/ipfs-gui/issues/50#issuecomment-419680213)
+        - [Released IPFS Companion v2.5.0](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.5.0). DNSLink is enabled by default now.
+        - [Created a sandbox illustrating current problems with the lack of range request semantics in libdweb's Protocol Handler API](https://github.com/lidel/libdweb/tree/video-range-use-case-demo/demo/protocol#dweb-range-request-sandbox)
+    - Next:
+        - PR Reviews, Go over Q3 backlog
+- @hacdias
+    - Last week:
+        - i18n https://github.com/ipfs-shipyard/ipfs-webui/pull/772 (props to @lidel)
+        - 💄ing the status page:
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/780
+            - https://github.com/ipfs-shipyard/ipfs-webui/issues/778
+
+- @alanshaw
+    - Last week:
+        - Made progress on `--cid-base` option to js-ipfs (working here https://github.com/ipfs/js-ipfs/tree/feat/cid-base-option)
+        - js-ipfs 0.32.0-rc.1 is out, rc.2 coming soon (waiting on https://github.com/ipfs/js-ipfs/pull/1543)
+    - Next:
+        - Send PR for `--cid-base`
+        - Write interop tests for retrieve from block store by any CID version
+        - Implement that ^^ in js-ipfs
+
+- @olizilla
+  - Done:
+    - Extracted IPLD explorer as a reusable module and use from IPLD Explorer and Web UI
+      - https://github.com/ipfs-shipyard/ipld-explorer-components
+    - WIP on i18n in story books for component only modules
+  - Next:
+    - fix perf issue or disable bandwidth per peer.
+    - Add ipfs provider info to status page
+    - handle ipfs connection errors.
+    - Web UI polish / snagging list.
+    - publish webui.ipfs.io
+    - user goals & user test scripts
+    - interviewing Dan Ordille
+
+- @fsdiogo
+    - Done:
+        - IPFS Share Files got deployed
+            - It’s not online yet because CI is giving me a fight 
+        - Worked on the landing pages for Companion
+            - https://github.com/ipfs-shipyard/ipfs-companion/pull/565
+    - Next:
+        - Landing pages for Companion
+        - Add copy to IPFS Share Files
+        - Add translations to IPFS Share Files
+
+
+### Discussion Highlights
+
+- Right now the entire team is in EU, so [we will move sync call to 9:30 AM UTC](https://github.com/ipfs/in-web-browsers/issues/106#issuecomment-419872656)
+- [PR](https://github.com/ipfs-shipyard/ipld-explorer-components/pull/1/files) with a neat way of passing HTML tags (formatting, links) into ICU translation keys: `Some <0>stuff</1>, some <1>other</1> stuff`
+- js-ipfs work related to cidv1b32 is progressing, adding support for `--cid-base` to all commands
+- [IPFS Translation Project at Transifex](https://www.transifex.com/ipfs/public/) is live! ([original issue](https://github.com/ipfs/ipfs-gui/issues/50))
+- It is okay for landing page in Companion to give shell command example when API is off. We will make it more user-friendly when IPFS Desktop in refreshed version lands.
+- We've identified [things that need to be done before we can ship WebUI](https://github.com/ipfs-shipyard/ipfs-webui/issues/749). 
+    - We want to get some community feedback before we PR a new hash to go-ipfs.
+
+### Action Items
+
+- @all: **think about OKRs for Q4**, [add async notes/ideas to the hackpad in this issue](https://github.com/ipfs/in-web-browsers/issues/110)
+-  @all: [any ideas on how we could get vanity hostnames for localhost gateway?](https://github.com/ipfs/in-web-browsers/issues/109)
+- @lidel: create issue for UX when webui + companion produce problem due to config.get being blocked over window.ipfs
+  - done: https://github.com/ipfs-shipyard/ipfs-webui/issues/787

--- a/meeting-notes/2018/2018-09-17--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-09-17--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,131 @@
+# GUI & In Web Browsers Weekly Sync 2018-09-17
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @fsdiogo
+    - @lidel
+    - @olizilla
+    - @alanshaw
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- @lidel: Async Retrospective of the Q3  ([context&template](https://github.com/ipfs/pm/issues/698#issue-360560672))
+    - Should we have separate docs for both WG? (@lidel: I think yes? It will make it easier to link/report on 26th)
+- Schedule Q4 OKR Planning Call this week
+- @lidel: PSA: feel free to add i18n tips and best practices to JavaScript section in  https://github.com/ipfs/i18n
+
+## Notes
+
+### Team Updates
+
+- @lidel
+    - Done:
+        - IPFS Translation Project (https://www.transifex.com/ipfs/public/)
+            - Some PMing, reviewing i18 PRs to WebUI, adding new language coordinators etc
+            - WIP: adding Memory Groups to share translations across all projects
+            - Moved various notes to a dedicated repo: https://github.com/ipfs/i18n
+        - IPFS Companion
+            - New beta: [v2.5.0.11250](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.5.0.11250)
+            - Reported&fixed [regression](https://github.com/mozilla/libdweb/issues/82) in libdweb branch with latest Firefox Nightly
+                - we may have more problems like this in future, Mozilla is doing cleanup of old/unused APIs
+            - Filled [Chromium bug: _Extensions API should implement manifest.json/protocol_handlers_](https://crbug.com/883274) to address UX issues from [arewedistributedyet/issues/23](https://github.com/arewedistributedyet/arewedistributedyet/issues/23#issuecomment-412892777). 
+                - This is an additional task on top of  _safelisting DWeb protocols_, which is tracked in https://crbug.com/651311.
+            - Investigation of [poor performance of files.add over window.ipfs in Firefox](https://github.com/ipfs-shipyard/ipfs-companion/issues/485), which manifests heavily when adding 2MB+ files with the latest WebUI. The issue is not present in Chrome, so far it looks like some events are fired twice in Firefox. 
+    - Next:
+        - Merge Landing Page to Companion
+        - Work on OKRs (Facilitate Q3 Retrospective, Planning Q4)
+        - Investigate regression found in [js-ipfs-http-response/pull/9](https://github.com/ipfs/js-ipfs-http-response/pull/9) with latest js-ipfs
+        - Prepare for bundling WebUI and share app with Companion (includes looking into [files.add over window.ipfs](https://github.com/ipfs-shipyard/ipfs-companion/issues/485))
+
+- @hacdias
+    - Done
+        - Reviewed some PRs
+        - Been working on a new IPFS Redux Bundle version:
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/792
+            - https://github.com/ipfs-shipyard/ipfs-redux-bundle/pull/5
+        - Tweaks on Share Files app:
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/26
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/27
+    - Next:
+        - Tweak last things on WebUI
+        - Start revamping Desktop (?)
+    - **Info** this will be my first week of classes so I'm not sure how much available I'll be yet.
+
+- @olizilla
+  - Done
+      - Web UI polishing for launch
+        - Tidy up UI for peers page - https://github.com/ipfs-shipyard/ipfs-webui/pull/793
+        - Disable bandwidth per peer & Tidy up UI for status page - https://github.com/ipfs-shipyard/ipfs-webui/pull/789
+        - Release IPLD Explorer with i18n magic and 5 locales 
+          - https://github.com/ipfs-shipyard/ipld-explorer-components/pull/1
+          - https://github.com/ipfs-shipyard/ipfs-webui/pull/788
+        - Fix i18n local loading to use relative paths
+        - PR infra for webui.ipfs.io (blocked on merge and deploy) - https://github.com/protocol/infra/pull/346
+        - IPFS React UI components library alpha - https://github.com/olizilla/ipfs-react
+
+  - Next
+      - use new ipfs-redux-bundle and update ipfs provider info on status page
+      - fix multiaddr parsing in ipfs-redux-bundle
+      - Add js-ipfs fallback to webui
+      - Move webui reavamp to master branch
+      - Add docs and user test plan
+      - Release webui to webui.ipfs.io and announce!
+      - PR go-ipfs
+      - Add Locale selector
+      - IPFS UI components library
+
+- @fsdiogo
+    - Done:
+        - Companion welcome page
+        - Welcome page i18n
+        - IPFS Share Files bugs
+        - Helped with js.ipfs.io
+    - Next:
+        - i18n to IPFS Share Files
+        - Add postcss and css-modules demo to IPFS UI Components
+
+
+### Discussion Highlights
+
+- Preparation for end of Q3 and Q4
+- Last mile for WebUI 2.0
+- @lidel's uplink dropped and we've lost the video :-(
+
+### Action Items
+
+- @lidel+@olizilla: Schedule Q4 OKR Planning Call this week
+- @lidel+@alanshaw: sync about [files.add over window.ipfs](https://github.com/ipfs-shipyard/ipfs-companion/issues/485)
+- @all: do async retrospective of Q3 ([links in this comment](https://github.com/ipfs/in-web-browsers/issues/110#issuecomment-421971836))

--- a/meeting-notes/2018/2018-09-24--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-09-24--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,125 @@
+# GUI & In Web Browsers Weekly Sync 2018-09-24
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @fsdiogo
+    - @alanshaw
+    - @olizilla
+    - @hacdias
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Finalize OKRs for Q4 so we can get some feedback from Matt
+- What is left for WebUI before big ship?
+
+## Notes
+
+### Team Updates
+
+- @lidel
+    - Done:
+        - Squashed some bugs
+        - Added some docs to https://github.com/ipfs/i18n
+        - Researched ways to [improve context menus in Companion](https://github.com/ipfs-shipyard/ipfs-companion/pull/585#issuecomment-422999186)
+        - [Initial stab at shipping WebUI with Companion](https://github.com/ipfs-shipyard/ipfs-companion/pull/590)
+        - [Added support for CIDv1 and Base32 to js-ipfs-http-response](https://github.com/ipfs/js-ipfs-http-response/pull/9)
+          (the lib is re-used in libdweb branch of Companion)
+    - Next:
+        - Finalize OKRs, prepare for OKR call on 26th
+        - Release Companion Beta with WebUI?
+        
+- @fsdiogo
+    - Done:
+        - Shipped Companion welcome page \o/
+            - https://github.com/ipfs-shipyard/ipfs-companion/pull/565
+        - Fixed routing on Share Files
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/29
+        - Added i18n to Share Files
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/30
+        - Added copy to Share Files
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/32
+    - Next:
+        - Add loading states before download starts
+        - Complete the README on Share Files
+        - Add postcss and css-modules demo to IPFS UI Components
+
+- @olizilla
+  - Done: 
+    - Cleared the (known) backlog of issues for launching Web UI
+    - Make peers page fast - https://github.com/ipfs-shipyard/ipfs-webui/pull/801
+    - Gracefully handle ipfs connection failures https://github.com/ipfs-shipyard/ipfs-webui/pull/802
+    - Wire up ipfs provider info. Add links to ipfs impl and release notes where possible - https://github.com/ipfs-shipyard/ipfs-webui/pull/802
+    - Lazy load `ipld`. It's large, and only used if you start exploring ipld, so we only load it if you use it. https://github.com/ipfs-shipyard/ipfs-webui/pull/804
+  - Next: 
+    - Move webui revamp to master branch
+    - Release webui to webui.ipfs.io and announce!
+    - Define Q4 OKRs and present to Lab.
+    - IPFS WebUI user testing plan
+    - WebUI in IPFS Desktop first iteration
+
+- @hacdias
+  - Done:
+    - Improved IPFS Redux Bundle
+    - Reviewed some PRs
+    - Started researching for the new IPFS Desktop (https://github.com/ipfs-shipyard/ipfs-desktop/issues/661)
+  - Next:
+    - IPFS Desktop plan
+    - Start Working on IPFS Desktop
+
+- @alanshaw
+    - Done:
+        - Released new ipfs-postmsg-proxy
+            - Fixes window.ipfs slow buffer serialization in Firefox (https://github.com/tableflip/ipfs-postmsg-proxy/pull/35)
+            - Adds some unimplemented APIs (https://github.com/tableflip/ipfs-postmsg-proxy/commit/1e7919891bfd928976f974fd99e35a1cd6435a73)
+        - Almost finished work on `--cid-base` option for js-ipfs
+    - Next:
+        - OKRs
+        - Finish `--cid-base`
+        - On holiday 1st - 5th Oct
+      
+### Discussion Highlights
+
+- `window.ipfs` is now fast in Firefox, the [fix](https://github.com/tableflip/ipfs-postmsg-proxy/pull/35) shipped with latest Companion
+- WebUI is close to being released, we are doing final polish before v2.0
+- Translation project has a new home:  https://github.com/ipfs/i18n
+- Share app is coming together nicely!
+- OKR draft will happen this week, tracked in [#110](https://github.com/ipfs/in-web-browsers/issues/110)
+
+### Action Items
+
+- @all: work on OKRs
+- @all: go over webui PRs and provide feedback
+- @olizilla: review copy and suggest improvements for [Share app](https://github.com/ipfs-shipyard/ipfs-share-files)

--- a/meeting-notes/2018/2018-10-01--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-10-01--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,94 @@
+# GUI & In Web Browsers Weekly Sync 2018-10-01
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @olizilla
+    - @lidel
+    - @fsdiogo
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Check-in: are we okay with continuing having one sync for both WGs in Q4?
+- > {?}
+
+## Notes
+
+### Team Updates
+
+- @lidel
+    - Done:
+        - Finalized draft of [Q4 OKRs: ipfs-in-web-browsers](https://docs.google.com/spreadsheets/d/139lROP7-Ee4M4S7A_IO4iIgSgugYm7dct620LYnalII/#gid=755202447) and prepared update on Q3 and plans for Q4
+        - Solved cid issues and got PR to [add support for CIDv1 and Base32 to js-ipfs-http-response](https://github.com/ipfs/js-ipfs-http-response/pull/9) merged.
+        - Fixed [Companion detection in ipfs-redux-bundle in Chromium](https://github.com/ipfs-shipyard/ipfs-redux-bundle/pull/14)
+        - Created PoC for [optional translations of selected posts at blog.ipfs.io](https://github.com/ipfs/blog/pull/180)
+    - Next:
+        - Release Companion Beta with pending PRs (WebUI, improved context-menus, upload fix)
+        - Prepare talks for Lab Week
+
+- @olizilla
+  - Done:
+    - :rocket: Tag v2 of Web UI https://github.com/ipfs-shipyard/ipfs-webui/releases/tag/v2.0
+    - https://webui.ipfs.io - DNS and Jenkins config for continuous deployment from master
+    - Simplify the peers page - extract and optimise the map insted of dyamically generating it.
+    - First draft of the usability testing plan for Web UI
+    - PR to announce Web UI in ipfs daemon console output https://github.com/ipfs/js-ipfs/pull/1595
+    - Q3 OKRs review and Q4 OKR presentation
+
+  - Next:
+    - Initial user research for Lab week
+    - Fix p1 items on Web UI and PR to js-ipfs and go-ipfs
+    - IPFS Desktop release plan and dev
+
+- @fsdiogo
+    - Done:
+        - Add loading states before download starts
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/34
+        - Updated the README
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/35
+        - Add postcss and css-modules demo to IPFS UI Components
+            - https://github.com/olizilla/ipfs-react/pull/2
+        - WebUI fixes
+    - Next:
+        - Add CORS config to Share Files add page
+        - WebUI P0/P1s
+
+### Discussion Highlights
+
+- Everyone is focused on two things: shipping WebUI and finishing OKR planning :)
+
+### Action Items
+
+- @olizilla: <del>review: https://github.com/ipfs-shipyard/ipfs-redux-bundle/pull/14</del> done

--- a/meeting-notes/2018/2018-10-15--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-10-15--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,92 @@
+# GUI & In Web Browsers Weekly Sync 2018-10-15
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @fsdiogo
+    - @olizilla
+    - @hacdias
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added
+
+- Lab Week Summary?
+- Priorities for GUI team
+
+## Notes
+
+### Team Updates
+
+- @lidel
+    - Done (mostly before lab week):
+        - [created cross-platform orchestration for fetching webui from ipfs during companion build](https://github.com/ipfs-shipyard/ipfs-companion/pull/590#issuecomment-426827936)
+        - [investigated upload issues with ipfs-cluster](https://github.com/ipfs-shipyard/ipfs-companion/issues/600)
+        - [decoupled blog.ipfs.io from ipfs.io and fixed various bugs related to IPNS and DNSLink](https://github.com/ipfs/website/issues/274#issuecomment-427210000), tl;dr being:
+            - PR: [fix: redirect /blog to blog.ipfs.io with IPNS support](https://github.com/ipfs/website/pull/275)
+            - PR: [fix: blog permalinks that work on IPNS](https://github.com/ipfs/blog/pull/182)
+        - Lab Week
+    - Next:
+        - Go over AI from Lab Week notes
+        - New Bugfix Beta of Companion  
+
+- @fsdiogo
+    - Done:
+        - Add CORS config instructions to Share Files and WebUI
+            - https://github.com/ipfs-shipyard/ipfs-share-files/pull/40
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/839
+        - Add fixed footer with code links
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/809
+        - Add git revision
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/844
+        - Add Web UI intro to files page
+            - https://github.com/ipfs-shipyard/ipfs-webui/pull/847
+        - Glasgow Team Week
+
+
+### Discussion Highlights
+
+- Plan for ipfs-desktop
+    - focus on basics for first iteration 
+        - visual revamp / wireframes / i18n
+        - autoupdates for ipfs-desktop AND go-ipfs shipped with it 
+- Plan for ipfs-share-files
+    - come up with better onboarding text
+- Additional work around GUI
+    - paginated directory listing 
+    - alternative to http polling (realtime API)
+    - in general, identify missing APIs and communicate to *-ipfs 
+
+### Action Items
+
+- @all go over backlogs and AIs from Team Week

--- a/meeting-notes/2018/2018-10-22--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-10-22--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,107 @@
+# GUI & In Web Browsers Weekly Sync 2018-10-22
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @olizilla
+    - @lidel
+    - @alanshaw
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added Agenda Items
+
+- How did London Meetup go? :)
+
+## Notes
+
+### Team Updates
+
+@fsdiogo
+- Done:
+    - Updated  pie charts tooltip to display clearer info
+        - https://github.com/ipfs-shipyard/ipfs-webui/pull/859
+    - Fixed notify bundle to differentiate connection and files failures
+        - https://github.com/ipfs-shipyard/ipfs-webui/pull/860
+    - [WIP] Fixed storybook
+        - https://github.com/ipfs-shipyard/ipfs-webui/pull/862
+    - [WIP] Add language selector
+        - https://github.com/ipfs-shipyard/ipfs-webui/pull/866
+- Next:
+	- Week off
+
+@alanshaw
+- Done:
+  - [IPFS London meeetup](https://www.meetup.com/london-ipfs/events/255386386/)
+  - [Released js-ipfs-api@25](https://github.com/ipfs/js-ipfs-api/releases/tag/v25.0.0) with fix for big uploads
+    - @olizilla immediately found [#1638](https://github.com/ipfs/js-ipfs/issues/1638), and I fix [#1645](https://github.com/ipfs/js-ipfs/pull/1645)
+  - [Released js-ipfs 0.33.0-rc.1](https://github.com/ipfs/js-ipfs/issues/1635) with new Web UI \o/
+- Next:
+  - Complete work on `--cid-base` option for js-ipfs [#1552](https://github.com/ipfs/js-ipfs/pull/1552)
+
+
+@lidel
+- Done: 
+	- Created a summary about potential IPFS use cases for [Signed HTTP Exchanges and WebPackage](https://github.com/ipfs/in-web-browsers/issues/121)
+	- Tested IPFS Companion with [recently released](https://brave.com/new-brave-browser-release-available-for-general-download/) Chromium-based Brave Browser,  it can be installed from Chrome Web Store and [works without any changes](https://cloudflare-ipfs.com/ipfs/QmV7cL21fJUJ283d9Mwefty5YzdXMXDaRaj2z9bY3R2FnL/2018-10-22-105404_900x519_scrot.png) \o/  
+	- Researched why the [fix for random UI glitches: check only for recursive pins](https://github.com/ipfs-shipyard/ipfs-companion/pull/594) did not work in Companion
+		- Identified a bug in js-ipfs-api that ignores checks for specific pin types: [PR with fix](https://github.com/ipfs/js-ipfs-api/pull/875)
+		- Added regression tests in separate [PR for  interface-ipfs-core](https://github.com/ipfs/interface-ipfs-core/pull/375)
+- Next:
+	- Release Companion Beta
+	- Identify open problems and create work plan for ["window.ipfs" 2.0](https://github.com/ipfs-shipyard/ipfs-companion/issues/589)
+
+@hacdias
+- Done:
+	- Organized some issues related to IPFS Desktop's next version:
+		- https://github.com/ipfs-shipyard/ipfs-desktop/issues/669
+		- https://github.com/ipfs-shipyard/ipfs-desktop/issues/668
+		- https://github.com/ipfs-shipyard/ipfs-desktop/issues/618
+		- https://github.com/ipfs/ipfs-gui/issues/44
+		- **I need feedback from everyone reading this!** 😁
+- Next:
+	- Start working towards the new IPFS Desktop version:
+		- Decouple Settings screen from the main menubar to have more room and space to breath.
+
+### Discussion Highlights
+
+- IPFS London Meetup was a success, a lot of good talks 
+- ipfs-companion runs in Brave 0.55 
+- ipfs-webui will land in js-ipfs soon
+- Fixing bugs, ramping up for work on ipfs-desktop
+
+### Action Items
+
+- @all: provide feedback for ipfs-desktop issues and plan
+- @alanshaw: review PRs: [js-ipfs-api/pull/875](https://github.com/ipfs/js-ipfs-api/pull/875) & [interface-ipfs-core/pull/375](https://github.com/ipfs/interface-ipfs-core/pull/375) 
+- @olizilla & @alanshaw: figure out how to properly detect API port of js-ipfs in ipfs-webui

--- a/meeting-notes/2018/2018-10-29--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-10-29--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,125 @@
+# GUI & In Web Browsers Weekly Sync 2018-10-29
+
+- **Lead:** @olizlla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @fsdiogo
+    - @olizilla
+    - @alanshaw
+    - @hacdias
+    - @lidel
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+## Notes
+
+### Team Updates
+
+@lidel
+
+- Done
+    - Researched and documented strategies for: [What happens when i18n efforts grow bigger and cover more than IPFS?](https://github.com/ipfs/i18n/issues/3)
+    - Shared some context on preload nodes with @kyledrake and @eefahy. [Expired cert is fixed](https://github.com/ipfs/infrastructure/issues/443), FYSA Kyle is planning to move preload nodes to own infrastructure, where the cert will auto-update, preventing this in the future.
+    - Documented known issues and ways of improving UX of [`ipfs files write`](https://github.com/ipfs/interface-ipfs-core/blob/e5d90e29cab9735f12bbca225b76ba8273e3b9d8/SPEC/FILES.md#fileswrite) (trickle-dag) vs. [`ipfs files add`](https://github.com/ipfs/interface-ipfs-core/blob/e5d90e29cab9735f12bbca225b76ba8273e3b9d8/SPEC/FILES.md#filesadd) (default, merkle-dag) if we decide to [revamp IPFS Files API (hackpad by @olizilla)](https://hackmd.io/MzxjQdwfRWSj6bdbfk7p4g?view)
+    - [WIP] Researched design decisions and low level discussions related to `window.ethereum`, added more notes to [our issue](https://github.com/ipfs-shipyard/ipfs-companion/issues/589)
+- Blocked
+    - Need PR Review: [js-ipfs-api/pull/875](https://github.com/ipfs/js-ipfs-api/pull/875)
+- Next
+    - new beta ipfs-companion
+    - continue `window.ipfs 2.0`
+
+@alanshaw
+
+* Done
+    * Released `jsipfs@0.33.0-rc.2`
+        * Update to Web UI 2.1.1 [#1653](https://github.com/ipfs/js-ipfs/pull/1653)
+        * Remove Hapi `maxBytes` restriction allowing large file uploads from the browser [#1645](https://github.com/ipfs/js-ipfs/pull/1645)
+    * Released `jsipfs@0.33.0-rc.3`
+        * Allows the Web UI to detect and connect to origin without the user having to configure the API multiaddr [#1660](https://github.com/ipfs/js-ipfs/pull/1660)
+    * Attempted release 0.33, and delayed due to:
+        * Running tests for [orbitdb/ipfs-log](https://github.com/orbitdb/ipfs-log) failed with [#1615](https://github.com/ipfs/js-ipfs/issues/1615), now fixed by [#1617](https://github.com/ipfs/js-ipfs/pull/1617)
+        * `js-unixfs-engine` upgraded to `js-ipld@0.18` (a breaking change), causing 2 versions of `ipld` to be included in `js-ipfs`. Resolution is to also bring this breaking change into `js-ipfs@0.33`. PR open to resolve [#1668](https://github.com/ipfs/js-ipfs/pull/1668)
+    * Created **Awesome Endeavour: Async Iterators** [#1670](https://github.com/ipfs/js-ipfs/issues/1670)
+        * Converted `js-libp2p-crypto` and `js-libp2p-crypto-secp256k1` to use async/await over the weekend ([#131](https://github.com/libp2p/js-libp2p-crypto/pull/131) and [#9](https://github.com/libp2p/js-libp2p-crypto-secp256k1/pull/9))
+        * It faster! https://github.com/libp2p/js-libp2p-crypto/pull/131#issue-226279844
+    * PR open to AEgir for prereleases support [#289](https://github.com/ipfs/aegir/pull/289)
+* Blocked
+    * `n/a`
+* Next
+    * [Many PRs to review, merge and release for IPLD breaking change](https://github.com/ipfs/js-ipfs/pull/1668#issuecomment-433074668)
+    * Release `js-ipfs@0.33`
+    * Work on `--cid-base` option
+
+- @hacdias
+  - Done:
+    - Kept working on desktop with Oli's new designs: https://github.com/ipfs-shipyard/ipfs-desktop/pull/662
+  - Next:
+    - (this will be a *huge* week for me at uni so I won't be as available as usual)
+    - Keep working on Desktop
+    - Take a look at https://github.com/ipfs/js-ipfs/issues/1670
+
+- @fsdiogo
+    - Done:
+        - Week off
+    - Next:
+        - Finish pending PRs in the Web UI
+
+- @olizlla
+    - Done:
+      - IPFS Desktop design research and proposal https://github.com/ipfs/ipfs-gui/issues/44#issuecomment-432998304
+      - Make IPFS Web UI work out of the box with js-ipfs https://github.com/tableflip/uri-to-multiaddr/commit/82540e7edd6e182807142c36681eb3bcd1c4627f
+      - Fix https://libp2p.io/media/ layout https://github.com/libp2p/website/pull/85
+      - IPFS Roadmap refinements https://docs.google.com/document/d/13_4_23Jrth7HBZ1QD6ezJaLRYCHN32xJLA5c0z3IOkc/edit?ts=5bd2ee0d#
+    - Next:
+        - IPFS Roadmap wrangling
+        - Desktop project management
+        - I18n lang selector issues
+        - Get share app ready to integrate with webui 
+        - Upgrade ipld explorer and webui with latest IPLD breaking changes.
+
+### Discussion Highlights
+
+- @olizilla presented some mockups of simplified ipfs-desktop UI based on menu from ipfs-webui – [ipfs-gui/issues/44](https://github.com/ipfs/ipfs-gui/issues/44#issuecomment-432998304)
+  - @hacdias implemented a poc in [ipfs-desktop/pull/662](https://github.com/ipfs-shipyard/ipfs-desktop/pull/662#issuecomment-433200688) :))
+- ipfs-webui is being announced by js-ipfs daemon and is able to automagically discover its API port \o/
+- IPFS Roadmap for 2019: we should start thinking how our WGs fit within the bigger picture 
+- "window.ipfs 2.0" update by @lidel
+  - tl;dr we may not be able to avoid having 1 bit of fingerprinting surface due to UX, so we could just go with thin `window.ipfs` that returns full API after `window.ipfs.enable(<capabilities>)` call.
+  - feedback & details in [ipfs-companion/issues/589](https://github.com/ipfs-shipyard/ipfs-companion/issues/589)
+ - UX discussion around manual Language selector in ipfs-webui – [ipfs-webui/pull/866](https://github.com/ipfs-shipyard/ipfs-webui/pull/866/)
+ - Awesome Endeavour: Moving to Async Iterators in all JS libraries – [js-ipfs/issues/1670](https://github.com/ipfs/js-ipfs/issues/1670)
+ - Quick chat about decentralized annotations – [ipfs-shipyard/discussify-browser-extension](https://github.com/ipfs-shipyard/discussify-browser-extension)
+
+### Action Items
+
+- @all: read, comment and contribute to [IPFS Project Roadmap Doc](https://docs.google.com/document/d/13_4_23Jrth7HBZ1QD6ezJaLRYCHN32xJLA5c0z3IOkc/)

--- a/meeting-notes/2018/2018-11-05--gui-and-in-web-browsers-weekly.md
+++ b/meeting-notes/2018/2018-11-05--gui-and-in-web-browsers-weekly.md
@@ -1,0 +1,118 @@
+# GUI & In Web Browsers Weekly Sync 2018-11-05
+
+- **Lead:** @olizilla
+- **Notetaker:** @lidel
+- **Attendees:**
+    - @lidel
+    - @fsdiogo
+    - @olizilla
+    - @hacdias
+    - @alanshaw
+
+## Goals
+
+- [Web Browsers WG](https://github.com/ipfs/in-web-browsers)
+    - Browser developers are addressing requirements of the distributed web
+    - Ensure smooth experience for web developers in browser contexts
+    - Browser extension exposes IPFS features in a robust and intuitive form
+- [GUI WG](https://github.com/ipfs/ipfs-gui)
+    - Core IPFS features are intuitive and accessible to all
+    - Everyone is empowered to make great new IPFS user interfaces
+    - The GUIs push forward understanding and adoption of IPFS
+
+## Agenda
+
+### Before the Sync
+
+- Write down your updates
+    - What have you accomplished since the last Weekly?
+    - Were there any blockers? If so, which ones? Is it still blocked? Why?
+    - What is the next important thing you should focus on?
+- Read updates of others
+    - Any there any questions, requests to communicate?
+
+
+### Regular
+
+- Ask everyone to put their name into the list of attendees
+- Go over everyone's updates and ask if there are any questions or things to discuss
+- Everyone can demo something!
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+
+### Added Agenda Items
+
+- @lidel: Should we move meeting notes to ? 
+  - Current location: [ipfs/in-web-browsers/meeting-notes](https://github.com/ipfs/in-web-browsers/tree/master/meeting-notes)
+  - Alternative location: [ipfs/pm/meeting-notes/](https://github.com/ipfs/pm/tree/master/meeting-notes/2018)
+    - Why? Better discovery, JS, Cluster and DDC WGs are there
+- @lidel: sync with @Gozala – who can join? (today, right after js-core sync)
+
+## Notes
+
+### Team Updates
+
+@lidel
+
+- Done
+    - QA and interop testing of ipfs-webui related to directory uploads - [ipfs-webui/issues/872](https://github.com/ipfs-shipyard/ipfs-webui/issues/872)
+    - Fixed some bugs and released a new beta: [ipfs-companion v2.5.1.11970](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.5.1.11970)
+    - Updated `js-ipfs-api/examples/upload-file-via-browser` to work with big files and optionally keep filenames - [js-ipfs-api/pull/884](https://github.com/ipfs/js-ipfs-api/pull/884)
+    - [IPFS distributions website](https://dist.ipfs.io) will now publish checksums for every new artifact - [ipfs/distributions/pull/199](https://github.com/ipfs/distributions/pull/199)
+    - Added QUIC to js-multiaddr - [js-multiaddr/pull/71](https://github.com/multiformats/js-multiaddr/pull/71)
+        - band-aid release with fixed ipfs-webui: [ipfs-companion v2.5.1.12010](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.5.1.12010)
+    - github/email catch up
+    - Started some code related to window.ipfs 2.0 but run out of time last week :(
+- Blocked:
+    - We need [js-multiaddr/pull/71](https://github.com/multiformats/js-multiaddr/pull/71) to be merged & released to fix [ipfs-webui/issues/878](https://github.com/ipfs-shipyard/ipfs-webui/issues/878)
+    - Are we good with releasing WebUI with Companion Stable? (go-ipfs and js-ipfs both ship the new version..)
+- Next
+    - Release ipfs-companion to Stable?
+    - [Participate in the Origin Trial (Signed HTTP Exchanges)](https://developers.google.com/web/updates/2018/11/signed-exchanges) ([context](https://github.com/ipfs/in-web-browsers/issues/121))
+    - third time's a charm: window.ipfs 2.0
+
+- @hacdias
+  - Done:
+    - https://github.com/ipfs-shipyard/ipfs-desktop/issues/669
+  - Next:
+    - https://github.com/ipfs-shipyard/ipfs-desktop/issues/669
+
+@alanshaw
+* Done:
+    * Released `js-ipfs 0.33.0` - thanks for all the Web UI work! 🥰 💖
+    * We had a bumper week last week, MANY closed PRs and issues
+        * ![Throughput Graph](https://ipfs.io/ipfs/QmQeEyDPA47GqnduyVVWNdnj6UBPXYPVWogAQoqmAcLx6y)
+* Blocked:
+    * `null`
+* Next:
+    * Roadmapping 2019 for JS IPFS
+    * Work on `--cid-base` option
+
+@fsdiogo
+- Done:
+    - Language selector
+        - https://github.com/ipfs-shipyard/ipfs-webui/pull/866
+    - Storybook
+        - https://github.com/ipfs-shipyard/ipfs-webui/pull/862
+- Next:
+    - Storybook
+    - OKRs
+
+### Discussion Highlights
+
+- Bugfix/release week, shipping PRs and closing issues
+- PR with ipfs-desktop 1.0 
+    - How to expose ipfs-desktop settings without having two settings screens
+    - Expose them on Web UI Settings screen
+- Manual language selector lands in Web UI, some tooling is born out of necessity
+- [The 100th release of IPFS Companion!](https://github.com/ipfs-shipyard/ipfs-companion/releases/tag/v2.5.1.11970)
+- [js-ipfs 0.33.0](https://blog.ipfs.io/51-js-ipfs-0-33/) \o/
+- Move Meeting Notes to ipfs/pm? Yup. – [#130](https://github.com/ipfs/in-web-browsers/issues/130)
+- Sync with @Gozala scheduled after js-core call
+
+### Action Items
+
+- @all: spend some time thinking about priorities in 2019
+- @lidel: write some thoughts on exposing ipfs-desktop settings in ipfs-webui - DONE: [ipfs-desktop/issues/674 (comment)](https://github.com/ipfs-shipyard/ipfs-desktop/issues/674#issuecomment-436251422)
+- @lidel, @alanshaw, @olizilla – sync with @Gozala


### PR DESCRIPTION
This PR moves meeting notes
from https://github.com/ipfs/in-web-browsers/tree/master/meeting-notes  
to this repo and closes https://github.com/ipfs/in-web-browsers/issues/130

The move aims to improve discoverability and solve the awkward situation where [ipfs-gui](https://github.com/ipfs/ipfs-gui) had meeting notes of joint sync call in [in-web-browsers](https://github.com/ipfs/in-web-browsers) repo :upside_down_face: 