### PR TITLE
Add links to IPLD and libp2p planning repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## Repo Index
 
+- [Related Projects](#related-projects)
 - [How We Work](#how-we-work)
 - [Teams](TEAM_STRUCTURES.md)
 - [Asynchronous Communitication](#asynchronous-communication)
@@ -27,6 +28,13 @@
 - [Timezone: UTC](#timezone-utc)
 - [Contribute](#contribute)
 - [License](#license)
+
+## Related Projects
+
+IPFS leverages several related projects which have their own planning:
+
+ - [IPLD](https://github.com/ipld/team-mgmt)
+ - [libp2p](https://github.com/libp2p/team-mgmt)
 
 ## How We Work
 


### PR DESCRIPTION
I'd expect IPFS being kind of the central entry point even
for related projects. Hence make them easy to find at the
top of the README.