### PR TITLE
Team Roles Doc - People Coaches

### DIFF
--- a/TEAM_ROLES.md
+++ b/TEAM_ROLES.md
@@ -2,20 +2,26 @@
 
 The individual contributors to the IPFS Project and Org often find themselves wearing many hats while performing their day to day tasks or on the projects they are focused on. We enable this by design to make the IPFS Org very permeable and empower each team to find its perfect balance for the challenges they are facing.
 
-This doc presents the definition of only two roles, these are a) the ones we identified as necessary to have a well functioning Working Group and b) the ones that raise more questions. There are many other roles (project manager, designer, UX researcher, developer, systems engineer, etc), that we are not defining in this doc (yet).
+This doc presents the definition of only three roles, these are a) the ones we identified as important to have a well functioning Working Group and b) the ones that raise more questions. There are many other roles (product manager, designer, UX researcher, developer, systems engineer, etc), that we are not defining in this doc (yet).
 
 ## IPFS Working Groups specific roles
 
-There are mainly two that are unique to our [Team Structures](TEAM_STRUCTURES.md). The responsibilities within these roles can be shared between multiple individuals, however, they must be owned by a single person that takes the responsibility to ensure the work is happening.
+There are mainly three roles that are important to define for our [Team Structures](TEAM_STRUCTURES.md). The responsibilities within these roles can be shared between multiple individuals, however, responsibility for a role must be owned by a single person that ensures the work is happening.
 
 ### Captain
 
-The Working Group Captain is a champion for the Product and/or Focus Area. They takes the lead on writing or guiding the conversation specs, documentation and other artifacts to support the team. The Captain is also the gatekeeper of the Working Group Roadmap and accumlator of the Working Group Knowledge, guiding the group to made good decisions.
+The Working Group Captain is a champion for the Product and/or Focus Area. They take the lead on writing or guiding the conversation specs, documentation and other artifacts to support the team. The Captain is also the gatekeeper of the Working Group Roadmap and accumlator of the Working Group Knowledge, guiding the group to made good decisions.
 
-### Technical Manager
+### Technical Project Manager (TPM)
 
-The Technical Manager (sometimes referenced as Project Manager, Technical Project Manager and cat herder) is a team enabler. They own the Quarterly Planning process including OKRs and Retrospectives. They ensure that the coordination strategy the WG selected is well executed (weekly syncs, taking notes, communicating needs to other WGs).
+The Technical Project Manager (sometimes referenced as Project Manager, Program Manager, and cat herder) is a team enabler. They own the Quarterly Planning process including OKRs and Retrospectives. They ensure that the coordination strategy the WG selected is well executed (weekly syncs, taking notes, communicating needs to other WGs).
 
-The Technical Manager should also have a role on contributing to the projects the Working Group is tackling and have an understanding of the technical challenges and needs from the team.
+The Technical Project Manager should also have a role on contributing to the projects the Working Group is tackling and have an understanding of the technical challenges and needs from the team.
 
-It happens that some working groups are ok with having the same person playing the Captain + Technical Manager role together, it works for when the Working Group is nascent or the team is small.
+It happens that some working groups are ok with having the same person playing the Captain + Technical Project Manager role together, it works for when the Working Group is nascent or the team is small.
+
+### People Coach
+
+The People Coach (sometimes referenced as the People Manager or Tech Lead Manager) is responsible for the effectiveness, productivity, and support systems for the Working Group team members. They ensure that contributors have someone to talk to about their growth and leveling-up, a knowledgeable source of feedback and review, and someone who can address any interpersonal issues.
+
+People coaching is still nascent in the IPFS Working Groups, so most guidance/support is on demand and ad hoc. Most of the folks wearing the "People Coach" hat for a Working Group do so in conjunction with other roles, and mainly act as routers and resources to connect team members to the right support systems.

--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -69,8 +69,7 @@ A byproduct of both of these team structures achieves another important goal: ma
 ### Project
 
 - **Coordination**: https://github.com/ipfs/project
-- **Captain**: [David Dias](https://github.com/diasdavid)
-- **Technical Manager**: same as the Captain
+- **[David Dias](https://github.com/diasdavid): Captain, TPM, People Coach**
 
 The IPFS Project Working Group Community serves as the point of coordination for the IPFS Organization.
 
@@ -84,8 +83,8 @@ The IPFS Project Working Group Community serves as the point of coordination for
 ### JavaScript IPFS implementation
 
 - **Coordination**: https://github.com/ipfs/pm/blob/master/JS_CORE_DEV_MGMT.md
-- **Captain**: [Alan Shaw](https://github.com/alanshaw/)
-- **Technical Manager**: `To be confirmed`
+- **[Alan Shaw](https://github.com/alanshaw/): Captain**
+- **`To be confirmed`: TPM, People Coach**
 
 
 Develop js-ipfs.
@@ -96,8 +95,8 @@ Develop js-ipfs.
 ### Golang IPFS implementation
 
 - **Coordination**: https://github.com/ipfs/pm/blob/master/GOLANG_CORE_DEV_MGMT.md
-- **Captain**: [Steven Allen](https://github.com/stebalien)
-- **Technical Manager**: [Erik Ingenito](https://github.com/eingenito)
+- **[Steven Allen](https://github.com/stebalien): Captain**
+- **[Erik Ingenito](https://github.com/eingenito): TPM, People Coach**
 
 Develop go-ipfs.
 
@@ -107,8 +106,7 @@ Develop go-ipfs.
 ### IPFS GUI
 
 - **Coordination**: https://github.com/ipfs/ipfs-gui
-- **Captain**: [Oli Evans](https://github.com/olizilla)
-- **Technical Manager**: same as the Captain
+- **[Oli Evans](https://github.com/olizilla): Captain, TPM, People Coach**
 
 Making IPFS GUIs simple, accessible, reusable, and beautiful.
 
@@ -121,8 +119,7 @@ Making IPFS GUIs simple, accessible, reusable, and beautiful.
 ### IPFS Cluster
 
 - **Coordination**: https://github.com/ipfs/ipfs-cluster
-- **Captain**: [Hector Sanjuan](https://github.com/hsanjuan)
-- **Technical Manager**: same as the Captain
+- **[Hector Sanjuan](https://github.com/hsanjuan): Captain, TPM, People Coach**
 
 The IPFS Cluster Working Group is the team implementing IPFS Cluster.
 
@@ -133,8 +130,7 @@ The IPFS Cluster Working Group is the team implementing IPFS Cluster.
 ### IPFS Infrastructure
 
 - **Coordination**: http://github.com/ipfs/infrastructure
-- **Captain**: [Erin Fahy](https://github.com/eefahy)
-- **Technical Manager**: same as the Captain
+- **[Erin Fahy](https://github.com/eefahy): Captain, TPM, People Coach**
 
 Tools and systems for the IPFS community.
 
@@ -148,8 +144,7 @@ Tools and systems for the IPFS community.
 ### `PAUSED` Dev Team Enablement (QA, Testing, Support)
 
 - **Coordination**: https://github.com/ipfs/testing
-- **Captain**: Ship is without a Captain
-- **Technical Manager**: N/A
+- **Ship is without a Captain, TPM, People Coach**
 
 The QA, Testing and Dev Team Enablement Working Group focuses on building developer tools, CI, and automated maintenance tasks to improve the developer experience of the many IPFS (and related) projects.
 
@@ -164,8 +159,7 @@ The QA, Testing and Dev Team Enablement Working Group focuses on building develo
 ### Community
 
 - **Coordination**: https://github.com/ipfs/community
-- **Captain**: [Mikeal Rogers](https://github.com/mikeal)
-- **Technical Manager**: same as the Captain
+- **[Mikeal Rogers](https://github.com/mikeal): Captain, TPM, People Coach**
 
 Community outreach working group. Coordinates the communities around events, blog posts
 documentation, automation and education.
@@ -188,8 +182,7 @@ documentation, automation and education.
 ### Integration with Web Browsers
 
 - **Coordination**: https://github.com/ipfs/in-web-browsers
-- **Captain**: [Marcin Rataj](https://github.com/lidel)
-- **Technical Manager**: same as the Captain
+- **[Marcin Rataj](https://github.com/lidel): Captain, TPM, People Coach**
 
 The Integration with Web Browsers Working Group designs and implements browser integrations, web extensions, service workers and any other strategy that contributes to IPFS being integrated with the web today.
 
@@ -206,8 +199,7 @@ The Integration with Web Browsers Working Group designs and implements browser i
 ### Dynamic Data and Capabilities
 
 - **Coordination**: http://github.com/ipfs/dynamic-data-and-capabilities
-- **Captain**: [Pedro Teixeira](https://github.com/pgte)
-- **Technical Manager**: same as the Captain
+- **[Pedro Teixeira](https://github.com/pgte): Captain, TPM, People Coach**
 
 Research and development of building blocks that enable collaborative applications, providing solutions for security, identity, access control, concurrency, synchronization, offline, and near-real-time collaboration. This WG was born out of the results created by the [CRDT Research Group](http://github.com/ipfs/research-crdt).
 
@@ -220,8 +212,7 @@ Research and development of building blocks that enable collaborative applicatio
 ### Decentralized Data Stewardship
 
 - **Coordination**: https://github.com/ipfs/decentralized-data-stewardship
-- **Captain**: [Michelle Hertzfeld](https://github.com/meiqimichelle)
-- **Technical Manager**: same as the Captain
+- **[Michelle Hertzfeld](https://github.com/meiqimichelle): Captain, TPM, People Coach**
 
 User research, collaborations, and products that support holding data together on decentralized networks.
 


### PR DESCRIPTION
This PR is a modification of a PR that David put together to more clearly define team roles. This modification:
- Adds a People Coach role
- Turns Tech Manager --> Technical Project Manager (TPM)
- Rephrases role of roles in WGs (so meta)
- Modifies the team structures doc based on these changes to call out Captains, TPMs, and People coaches

**NOTE: this PR doesn't suggest **any** new people coaching practices, it simply uses the "people coach" designation to direct any WG members needing support to their first router.