### PR TITLE
fix: community wg will not manage social media

### DIFF
--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -169,7 +169,7 @@ documentation, automation and education.
 **Responsibilities include**:
 - Help community members organize meetups for their own communities.
 - Respond to requests for IPFS presence in conferences.
-- Managing the official social media channels.
+- Fascilitate community content for social media channels.
 - Publish regular updates to the community (blog posts and newsletters).
 - Create Tutorials and Workshops to teach concepts about IPFS and the Distributed Web in ProtoSchool.
 - Ensure that public forums (discuss.ipfs.io, irc, github, etc) have adequate moderation and responsive support.

--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -169,7 +169,7 @@ documentation, automation and education.
 **Responsibilities include**:
 - Help community members organize meetups for their own communities.
 - Respond to requests for IPFS presence in conferences.
-- Fascilitate community content for social media channels.
+- Facilitate community content for social media channels.
 - Publish regular updates to the community (blog posts and newsletters).
 - Create Tutorials and Workshops to teach concepts about IPFS and the Distributed Web in ProtoSchool.
 - Ensure that public forums (discuss.ipfs.io, irc, github, etc) have adequate moderation and responsive support.


### PR DESCRIPTION
Social media resources will be managed by a Communications team. The Community WG will bridge the community with that group and facilitate getting community content into those feeds.