### PR TITLE
Add Working Group Mailing Lists

### DIFF
--- a/TEAM_STRUCTURES.md
+++ b/TEAM_STRUCTURES.md
@@ -72,6 +72,7 @@ A byproduct of both of these team structures achieves another important goal: ma
 
 - **Coordination**: https://github.com/ipfs/pm/blob/master/JS_CORE_DEV_MGMT.md
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_JS_CORE.md
+- **Working Group Mailing List**: js-ipfs-wg@ipfs.io
 - **[Alan Shaw](https://github.com/alanshaw/): Captain**
 - **`To be confirmed`: TPM**
 
@@ -88,6 +89,7 @@ Develop the JavaScript implementation of the IPFS Protocol, js-ipfs.
 
 - **Coordination**: https://github.com/ipfs/pm/blob/master/GOLANG_CORE_DEV_MGMT.md
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_GO_CORE.md
+- **Working Group Mailing List**: go-ipfs-wg@ipfs.io
 - **[Steven Allen](https://github.com/stebalien): Captain**
 - **[Erik Ingenito](https://github.com/eingenito): TPM**
 
@@ -103,6 +105,7 @@ Develop the Golang implementation of the IPFS Protocol, go-ipfs.
 
 - **Coordination**: https://github.com/ipfs/ipfs-gui
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_GUI.md
+- **Working Group Mailing List**: gui-wg@ipfs.io
 - **[Oli Evans](https://github.com/olizilla): Captain, TPM**
 
 Making IPFS GUIs simple, accessible, reusable, and beautiful.
@@ -117,6 +120,7 @@ Making IPFS GUIs simple, accessible, reusable, and beautiful.
 
 - **Coordination**: https://github.com/ipfs/ipfs-cluster
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_CLUSTER.md
+- **Working Group Mailing List**: cluster-wg@ipfs.io
 - **[Hector Sanjuan](https://github.com/hsanjuan): Captain, TPM**
 
 The IPFS Cluster Working Group is the team implementing IPFS Cluster.
@@ -129,6 +133,7 @@ The IPFS Cluster Working Group is the team implementing IPFS Cluster.
 
 - **Coordination**: http://github.com/ipfs/infra
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_INFRASTRUCTURE.md
+- **Working Group Mailing List**: infra-wg@ipfs.io
 - **[Erin Fahy](https://github.com/eefahy): Captain, TPM**
 
 Tools and systems for the IPFS community.
@@ -146,6 +151,7 @@ Tools and systems for the IPFS community.
 
 - **Coordination**: https://github.com/ipfs/in-web-browsers
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_INTEGRATION_IN_WEB_BROWSERS.md
+- **Working Group Mailing List**: wb-wg@ipfs.io
 - **[Marcin Rataj](https://github.com/lidel): Captain, TPM**
 
 The Integration with Web Browsers Working Group designs and implements browser integrations, web extensions, service workers and any other strategy that contributes to IPFS being integrated with the web today.
@@ -164,6 +170,7 @@ The Integration with Web Browsers Working Group designs and implements browser i
 
 - **Coordination**: http://github.com/ipfs/dynamic-data-and-capabilities
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_DYNAMIC_DATA_AND_CAPABILITIES.md
+- **Working Group Mailing List**: ddc-wg@ipfs.io
 - **[Pedro Teixeira](https://github.com/pgte): Captain, TPM**
 
 Research and development of building blocks that enable collaborative applications, providing solutions for security, identity, access control, concurrency, synchronization, offline, and near-real-time collaboration. This WG was born out of the results created by the [CRDT Research Group](http://github.com/ipfs/research-crdt).
@@ -178,6 +185,7 @@ Research and development of building blocks that enable collaborative applicatio
 
 - **Coordination**: https://github.com/ipfs/decentralized-data-stewardship
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_DECENTRALIZED_DATA_STEWARDSHIP.md
+- **Working Group Mailing List**: dds-wg@ipfs.io
 - **[Michelle Hertzfeld](https://github.com/meiqimichelle): Captain, TPM**
 
 User research, collaborations, and products that support holding data together on decentralized networks.
@@ -193,6 +201,7 @@ User research, collaborations, and products that support holding data together o
 
 - **Coordination**: https://github.com/ipfs/local-offline-collab
 - **Roadmap**: TBD
+- **Working Group Mailing List**: locol-wg@ipfs.io
 - **[Molly Mackinlay](https://github.com/momack2): Captain, TPM**
 
 User research, collaborations, and features to make the knowledge and tools on the internet accessible and useful on partitioned, low-bandwidth, or intermittant networks.
@@ -208,6 +217,7 @@ User research, collaborations, and features to make the knowledge and tools on t
 
 - **Coordination**: https://github.com/ipfs/project
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_PROJECT.md
+- **Working Group Mailing List**: project-wg@ipfs.io
 - **[David Dias](https://github.com/diasdavid): Captain, TPM**
 
 The IPFS Project Working Group Community serves as the point of coordination for the IPFS Organization.
@@ -223,6 +233,7 @@ The IPFS Project Working Group Community serves as the point of coordination for
 
 - **Coordination**: https://github.com/ipfs/community
 - **Roadmap**: https://github.com/ipfs/roadmap/blob/master/WG_COMMUNITY.md
+- **Working Group Mailing List**: community-wg@ipfs.io
 - **[Mikeal Rogers](https://github.com/mikeal): Captain, TPM**
 
 Community outreach working group. Coordinates the communities around events, blog posts


### PR DESCRIPTION
These mailing lists are meant for 1) coordination among active working group contributors and 2) private/sensitive outreach to a particular working group - they are **not** announce lists for working group efforts, nor should they be the default communication channel for bugs, feature requests, discussions, or ideas. Please continue to use Github, Discussify, or IRC to make sure we keep communication, ideas, and discussion accessible and useful to the whole IPFS community whenever possible! =]

Ref https://github.com/ipfs/project/issues/10