### PR TITLE
docs: make package managers weekly notes public

### DIFF
--- a/meeting-notes/2019/Q1/2019-02-12--package-managers-weekly.md
+++ b/meeting-notes/2019/Q1/2019-02-12--package-managers-weekly.md
@@ -1,0 +1,77 @@
+# 📦 Package Managers Weekly Sync
+
+## February 12, 2019
+
+- **Lead:** @achingbrain
+- **Notetaker:** @olizilla
+- **Attendees:**
+  - @achingbrain
+  - @warpfork
+  - @andrew
+  - @hsanjuan
+  - @daviddias
+
+- **Recording:** [Google Drive](https://drive.google.com/drive/u/3/folders/1xPO6Ei6In4hEoAnKZVnBRg3gCKsmls9z)
+
+## Agenda
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+- Plan this week
+  - Select issues to work on
+- Review remaining issues if there is time left
+
+## Updates
+
+@achingbrain
+- Done:
+  - Stabilised npm-on-ipfs deployment
+  - Made a plan with infra to deploy to a container service
+  - Investigate memory leak
+- Blocked:
+  - N/A
+- Next:
+  - Investigate memory leak
+  - Update roadmap
+  - Get proper zoom account
+  - Write npm-on-ipfs blog post
+
+@andrew
+- Done:
+  - started recategorizing spreadsheeet of package managers support
+  - getting familiar with npm-on-ipfs
+- Blocked:
+ - N/A
+- Next:
+  - investigating general purpose version of npm-on-ipfs
+  - further spreadsheet shuffling
+
+@name
+- Done:
+- Blocked:
+- Next:
+
+
+### Notes
+
+- write-file-atomic causing issues. nearform work is in progress to replace it.
+- Andrew is updating the package managers ecosystem spreadsheet. It might not stay a spreedsheet forever, as it feels like a 4d problem space.
+- Action: we need more folks to try npm-on-ipfs, for feedback / see the pain points
+- Action: start a doc / list of capabilities that we know we need already to do a good job of integrating with package managers, to help focus other working groups
+- Action: What are the talking points and exciting ideas in using IPFS for package-managers... Can we publish some interesting blog posts on these ideas
+  - Rabin chunker on expanded tarballs may not be better than storing packed tarballs
+    - https://github.com/ipfs-shipyard/ipfs-npm-registry-mirror/issues/6
+    - our current rabin impl would be easy to improve... we need to dedicate time to it.
+  - A story about all the packages a developer downloads and re-downloads over the course of a day / week
+  - the npm graveyard, all the modules that got yanked from npm that are still on npm-on-ipfs
+- Andrew looking at adapting npm-on-ipfs so that it can be used as a general purpose artefactory-like app that can be used by dev teams.
+- Andrew speculating on what happens when multiple folks in a decentralized way fetch parts of an existing registry content.  Reproducible import becomes relevant!
+
+
+

--- a/meeting-notes/2019/Q1/2019-02-19--package-managers-weekly.md
+++ b/meeting-notes/2019/Q1/2019-02-19--package-managers-weekly.md
@@ -1,0 +1,66 @@
+# 📦 Package Managers Weekly Sync
+
+## February 19, 2019
+
+- **Lead:** @achingbrain
+- **Notetaker:**
+- **Attendees:**
+  - @achingbrain
+  - @andrew
+  - @name
+
+- **Recording:** [Google Drive](https://drive.google.com/drive/u/3/folders/1AOctcPhoQhAhxsBL3LNAbQCJ3UQi1Lv2)
+
+## Agenda
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+- Plan this week
+  - Select issues to work on
+- Review remaining issues if there is time left
+
+## Updates
+
+@achingbrain
+- Done:
+  - Enabled netdata logging for ipfs-npm-registry-mirror
+  - Investigated memory leak on ipfs-npm-registry-mirror
+  - Written blog posts on npm-on-ipfs & ipfs-npm-registry-mirror
+- Blocked:
+  - N/a
+- Next:
+  - Investigate pubsub bug on ipfs-npm-registry-mirror
+
+@andrew
+- Done:
+  - Added cors support to ipfs-npm-registry-mirror
+  - spiked out simple search UI for npm-on-ipfs: https://andrew.github.io/npm-ipfs/index.html 
+  - started writing up short-ish term roadmap thoughts https://docs.google.com/document/d/1-HtUiRpMzYq9to56ShCGyCr-NCZ6TR49Zl-b5HHJdm0/edit#heading=h.5zpzsg32y0bx
+- Blocked:
+  - N/A
+- Next:
+  - experiment with a bundler ipfs plugin
+  - contact some package maintainers to interview about using IPFS
+  - more roadmapping
+
+@name
+- Done:
+- Blocked:
+- Next:
+
+
+### Notes
+
+- @achingbrain away until March 3rd
+- Need to follow up with infra about custom metrics in netdata
+- Create a browser plugin that adds CIDs to the npm website?
+- Enable DHT in ipfs-npm-registry-mirror?
+- Need high-level requirements for other working groups
+- Survey data from registry maintainers (storage size, bandwidth, record counts)
+

--- a/meeting-notes/2019/Q1/2019-03-12--package-managers-weekly.md
+++ b/meeting-notes/2019/Q1/2019-03-12--package-managers-weekly.md
@@ -1,0 +1,75 @@
+# 📦 Package Managers Weekly Sync
+
+## March 12, 2019
+
+- **Lead:** @achingbrain
+- **Notetaker:** @jimpick
+- **Attendees:**
+  - @achingbrain
+  - @andrew
+  - @jimpick
+  - @olizilla
+  - @daviddias
+  - @momack2
+  - @warpfork
+- **Recording:** https://drive.google.com/drive/u/3/folders/14HQshg-RqCWb9i4txh8KG6CBLtmN9-TA
+
+## Agenda
+
+- Ask everyone to put their name into the list of attendees
+- Round of updates
+  - What have you accomplished since the last Weekly?
+  - Were there any blockers? If so, which ones? Is it still blocked? Why?
+  - What is the next important thing you should focus on?
+- Ask for general questions. Could be things like:
+  - I'm stuck with something, I don't know who to ask. Who knows who to ask?
+  - Who can help me with xyz?
+- Plan this week
+  - Select issues to work on
+- Review remaining issues if there is time left
+
+## Updates
+
+@achingbrain
+- Done:
+  - Addressed npm-on-ipfs blog comments: https://github.com/ipfs/blog/pull/215
+  - Fixed MFS bug that was affecting npm-on-ipfs: https://github.com/ipfs/js-ipfs-mfs/pull/46
+  - Interviews
+- Blocked:
+  - N/A
+- Next:
+  - Implement js-ipfs DAG api
+
+
+@andrew
+- Done:
+  - [Follow up from implementation categories](https://github.com/protocol/package-managers/issues/14#issuecomment-471646464)
+  - [Towards publicizing the Package Managers Working Group](https://github.com/protocol/package-managers/issues/15)
+  - [List Problems with Package Managers](https://github.com/protocol/package-managers/issues/17)
+  - [Experiment: Setting up an Ubuntu mirror on IPFS](https://github.com/protocol/package-managers/issues/18)
+  - [Experiment: Setting up a Clojars mirror on IPFS](https://github.com/protocol/package-managers/issues/19)
+  - [Call with Todd Gamblin of Spack package manager](https://github.com/protocol/package-managers/issues/20)
+- Blocked:
+  - n/a
+- Next:
+  - [Presentation to IPFS Project WG](https://docs.google.com/presentation/d/1Erz7_Ifsdvd54Gi0JYBiyWKte8Gau_indqr8dSnS_ko/edit#slide=id.g528bbcf72b_0_61)
+  - London Meetup with Alex, Oli and Alan
+
+@name
+- Done:
+- Blocked:
+- Next:
+
+
+### Notes
+
+- @andrew
+  - It took 12 hours to sync Ubuntu to IPFS
+  - need docs to help package manager people get up-to-speed with IPFS
+  - @jim: it would be cool to turn importing Ubuntu into a test case
+  - @adin: why AFS? @andrew: Needs permissions for sensitive government stuff
+  - @david: get list of hard performance requirements - grouped by package manager
+            (in visual form)
+  - @achingbrain: needs to be faster than http
+  - @andrew: documentation needs to be leveled up
+  - @david: documentation: drive it by blog posts


### PR DESCRIPTION
N.b. meeting recordings are still in a private Google Drive, I need to upload them to the IPFS YouTube channel but I don't think I have access.