### PR TITLE
Replace monthly "5 min presentations" with show and tell

### DIFF
--- a/IPFS_WEEKLY_CALL.md
+++ b/IPFS_WEEKLY_CALL.md
@@ -15,7 +15,7 @@ The 30-minute IPFS Weekly Update takes place weekly on Mondays at:
 
 Each week's call will feature one or more short talks from guest presenters, in one of the following formats:
 - One 15-minute talk (3x per month)
-- Three 5-minute lightning talks (1x per month)
+- Show and tell with realtime signup for demos, feature intros, status updates, and questions (1x per month)
 
 <img src="https://res.cloudinary.com/blockchain-side-hustle/image/upload/v1541176158/ipfs_crew_xzbhxr.png" width="400"/>
 


### PR DESCRIPTION
We are never actually doing the "Three 5-minute lightning talks (1x per month)". Let's instead replace it with a nice change of pace from our normal presentation mode to have an "open mic night" as discussed at last week's Project Wg Weekly. This will give the community more time to share smaller realtime updates that they don't think to sign up for a top-level slot for. It will also hopefully create more cross-communication and be a time where folks who attend the call in person get a much richer experience than the 3x/month presentation.

To make this change stick, we also need to:
- [x] update the [schedule sign up](https://docs.google.com/spreadsheets/d/1XRB2QsPzCPLPOErKvDZfOKK3CMohI9t_QKNdztYMlK0/edit#gid=350755898) with a clear "show and tell" slot every 4th week (ai: @pkafei )
- [ ] modify the calendar invite to call out which meeting is the show and tell one (ai: @momack2 )
- [ ] ensure our call template calls out and explains the first show and tell call (ai: @pkafei )