### PR TITLE
feat: add meeting PR creator

### DIFF
--- a/tools/meeting-pr-creator/README.md
+++ b/tools/meeting-pr-creator/README.md
@@ -1,0 +1,10 @@
+Helper for creating meeting notes PR
+====================================
+
+This is a helper website to create a PR from our weekly meeting notes.
+
+Live instance can be found at:  https://ipfs.io/ipfs/bafybeiawbhupadrvo3vkmolvlrxys5a4didtevrmn5avtsntjzruotfxvm/
+
+It looks like this:
+
+> ![Screen Shot 2019-11-01 at 15 21 24](https://user-images.githubusercontent.com/157609/68031137-52d0a480-fcbb-11e9-91d4-ef656035207c.png)

--- a/tools/meeting-pr-creator/index.html
+++ b/tools/meeting-pr-creator/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Create PR for ipfs/team-mgmt Meeting</title>
+    <link rel="stylesheet" href="https://unpkg.com/tachyons@4.11.1/css/tachyons.min.css">
+    <link rel="stylesheet" href="https://unpkg.com/ipfs-css@0.13.1/ipfs.css">
+  </head>
+  <body class="sans-serif bg-white black">
+    <header class='pv3 ph2 ph3-l bg-navy cf'>
+      <a href="https://ipfs.io/" title='ipfs.io'>
+        <img src="https://ipfs.io/images/ipfs-logo.svg" class='v-mid' style='height:50px' />
+      </a>
+      <h1 class='aqua fw2 montserrat dib ma0 pv2 ph1 v-mid fr f3 lh-copy'>ipfs/team-mgmt meeting PR creator</h1>
+    </header>
+    <form>
+      <li>
+        <ol>
+          <label for="name" class="f6 b db mb2">Meeting Name (will be lowercased)</label>
+          <input id="name" type="text"
+            placeholder="i-was-too-lazy-to-change-this"
+            class="input-reset ba b--black-20 pa2 mb2 db w-70">
+        </ol>
+        <ol>
+          <label for="date" class="f6 b db mb2">Meeting date</label>
+          <input id="date" type="date" required
+            class="input-reset ba b--black-20 pa2 mb2 db">
+        </ol>
+        <ol>
+          <button type="submit"
+            class="f4 ba input-reset dim link pa2 mb2 pointer white bg-navy">
+            Create PR
+          </button>
+        </ol>
+        <ol class="mt4 charcoal-muted">
+          <small>( below fields are optional, better leave them alone )</small>
+        </ol>
+        <ol  class="charcoal-muted">
+          <label for="notes" class="f6 b db mb2">Notes URL</label>
+          <input id="notes" type="url"
+            placeholder="(leave empty to paste notes later)"
+            class="input-reset ba b--black-20 pa2 mb2 db w-70">
+        </ol>
+        <ol  class="charcoal-muted">
+          <label for="destination" class="f6 b db mb2">File location</label>
+          <input id="destination" type="url"
+            placeholder="https://github.com/ipfs/team-mgmt/blob/master/meeting-notes/${year}/${quarter}/${date}--${name}.md"
+            class="input-reset ba b--black-20 pa2 mb2 db w-70">
+        </ol>
+        <ol  class="charcoal-muted">
+          <label for="branch" class="f6 b db mb2">Branch name</label>
+          <input id="branch" type="text" placeholder="${name}-${date}"
+            class="input-reset ba b--black-20 pa2 mb2 db w-70">
+        </ol>
+        <ol  class="charcoal-muted">
+          <label for="commit-message" class="f6 b db mb2">Commit message "${date}" contains the <em>Meeting Date</em>)</label>
+          <textarea id="commit-message" type="text" rows="5"
+            placeholder="Add notes for ${name} ${date}"
+            class="input-reset ba b--black-20 pa2 mb2 db w-70"></textarea>
+        </ol>
+      </li>
+    </form>
+    <script type="text/javascript" src="script.js"></script>
+</body>
+</html>

--- a/tools/meeting-pr-creator/script.js
+++ b/tools/meeting-pr-creator/script.js
@@ -1,0 +1,82 @@
+// Return the placeholder if the input field doesn't have a value set
+const valueOrPlaceholder = (inputId) => {
+  const input = document.getElementById(inputId)
+  return input.value ? input.value : input.placeholder
+}
+
+// Replace every occurence of `${date}` with the given date
+const replaceDate = (input, date) => {
+  const d = new Date(Date.parse(date))
+  const year = d.getFullYear()
+  const quarter = `Q${Math.floor((d.getMonth() + 3) / 3)}`
+  return input.replace(/\$\{date\}/g, date)
+    .replace(/\$\{year\}/g, year)
+    .replace(/\$\{quarter\}/g, quarter)
+}
+
+const replaceName = (input, name) => input.replace(/\$\{name\}/g, name)
+
+// Split the commit message into its subject and description
+const splitCommitMessage = (message) => {
+  let [subject, ...description] = message.split('\n\n')
+  if (description === undefined) {
+      description = ''
+  } else {
+      description = description.join('\n\n')
+  }
+  return [subject, description]
+}
+
+// Parse the location where the file should be stored
+const parseDestination = (destination) => {
+  const [_empty, org, repo, _blob, branch, ...filepath] = decodeURI(
+    new URL(destination).pathname
+  ).split('/')
+  const filenameLiteral = filepath.pop()
+  const directory = filepath.join('/')
+  return { org, repo, branch, directory, filenameLiteral }
+}
+
+// Get all the values to construct the URL
+const getValues = async () => {
+  const notesUrl = document.getElementById('notes').value
+  const notes = notesUrl ? await (await fetch(notesUrl, {cache: 'no-store'})).text() : 'PASTE NOTES HERE =^.^='
+  const date = valueOrPlaceholder('date')
+  const destination = valueOrPlaceholder('destination')
+  let {
+    org, repo, branch, directory, filenameLiteral
+  } = parseDestination(destination)
+  const name = valueOrPlaceholder('name').replace(/ /g, '-').toLowerCase()
+  const filename = replaceName(replaceDate(filenameLiteral, date), name)
+  directory = replaceDate(directory, date)
+  const targetBranch = replaceName(replaceDate(valueOrPlaceholder('branch'), date), name)
+  const commitMessage = replaceName(replaceDate(valueOrPlaceholder('commit-message'), date), name)
+  const [commitSubject, commitDescription] = splitCommitMessage(commitMessage)
+  return {
+    org, repo, branch, directory, filename, targetBranch, commitSubject,
+    commitDescription, notes
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Set to todays date by default
+  document.getElementById('date').valueAsDate = new Date()
+
+  // Create the actual PR
+  document.getElementsByTagName('form')[0].addEventListener('submit', async (event) => {
+    // Don't submit, we do everything through JS
+    event.preventDefault()
+
+    const {
+      org, repo, branch, directory, filename, targetBranch, commitSubject,
+      commitDescription, notes
+    } = await getValues()
+
+    // Encode everything correctly
+    let url = encodeURI(`https://github.com/${org}/${repo}/new/${branch}?filename=${directory}/${filename}&quick_pull=master&target_branch=${targetBranch}&message=${commitSubject}&description=${commitDescription}&value=`)
+    url += encodeURIComponent(notes)
+
+    // Send the user to the new PR
+    window.location.href = url
+  })
+})


### PR DESCRIPTION
This PR adds a helper website to create a PR from our weekly meeting notes.

It is based on a [tool for ipld/team-mgmt](https://github.com/ipld/team-mgmt/tree/master/docs) made by @vmx :heart:  (thanks!)

I simplified it and adapted it to follow path conventions of `ipfs/team-mgmt` repo.
**In "lazy mode" you just enter the meeting name, select the date and press the button :ok_hand:** 
I find this flow the fastest, notes are pasted in the next step and we don't need to worry about fetch errors due to CORS setup on third party hackpad servers.

Live instance can be found at:  https://ipfs.io/ipfs/bafybeiawbhupadrvo3vkmolvlrxys5a4didtevrmn5avtsntjzruotfxvm/, feel free to bookmark it :bookmark_tabs: 

It looks like this:

> [![Screen Shot 2019-11-01 at 15 21 24](https://user-images.githubusercontent.com/157609/68031137-52d0a480-fcbb-11e9-91d4-ef656035207c.png)](https://ipfs.io/ipfs/bafybeiawbhupadrvo3vkmolvlrxys5a4didtevrmn5avtsntjzruotfxvm/)

cc'd people who often need to create such PRs manually. Feedback welcome.
