### PR TITLE
Updates docs link to non-beta site.

### DIFF
--- a/OKR/docs.md
+++ b/OKR/docs.md
@@ -5,7 +5,7 @@ The IPFS Docs team designs, builds, and maintains the documentation for at devel
 ## 2020 Q1
 Here's a summary of this team's objectives for the first three months of 2020:
 
-1. Launch the [beta IPFS documentation](https://docs-beta.ipfs.io/) site on the IPFS network.
+1. Launch the [beta IPFS documentation](https://docs.ipfs.io/) site on the IPFS network.
 2. Improve documentation by:
    1. Creating new content based on [existing issues](https://github.com/ipfs/docs/issues).
    2. Improve and update existing pages.

--- a/meeting-notes/2019/Q4/2019-11-25--ipfs-weekly-call.md
+++ b/meeting-notes/2019/Q4/2019-11-25--ipfs-weekly-call.md
@@ -42,7 +42,7 @@ _Show your work!_
     *   We previously had instructions on developing tutorials, but we weren’t telling people how to design effective content that fits the platform well -  what the guiding principles were, what content ProtoSchool could handle, etc etc etc 
     *   Plus, tips about how to create lessons - not accidentally teaching JS when you want to teach IPFS, what a manageable chunk of a section of a tutorial is, etc
     *   The existing guidance on how to build a ProtoSchool tutorial, from a development perspective, has been pulled out of the main readme and now lives [here](https://github.com/ProtoSchool/protoschool.github.io/blob/code/DEVELOPING_TUTORIALS.md).
-*   [IPFS Docs Beta](https://docs-beta.ipfs.io/) sneak peek
+*   [IPFS Docs Beta](https://docs.ipfs.io/) sneak peek
     *   Getting close to shipping a new beta version of an improved IPFS docs site! Check the link for a sneak peek. Ideally launch will be EOY.
     *   You can check the overall progress of the beta as well as all other docs attention items in our OKRs - they’re in the [readme](https://github.com/ipfs/docs) for our repo
     *   Docs also start on the front of the main IPFS website! So we improved guidance on the [front of ipfs.io](https://ipfs.io/#install ) to show people the different flavors of IPFS they may want to install based on what they actually want to do with IPFS

--- a/meeting-notes/2020/Q1/2020-01-13--core-implementations-weekly.md
+++ b/meeting-notes/2020/Q1/2020-01-13--core-implementations-weekly.md
@@ -57,7 +57,7 @@
 #### Subdomain Gateway (Base32, Origin isolation)
 @lidel
 
-- [Updated docs about gateways @ docs-beta.ipfs.io](https://docs-beta.ipfs.io/how-to/address-ipfs-on-web/#http-gateways)
+- [Updated docs about gateways @ docs.ipfs.io](https://docs.ipfs.io/how-to/address-ipfs-on-web/#http-gateways)
 - Did not start subdomain work yet (finishing Q4 leftovers) 
 
 #### Distributed Signaling (js-libp2p)
@@ -220,7 +220,7 @@
 @lidel
 - Done:
   - subdomain gateways
-    - docs-beta.ipfs.io: [docs: subdomain gateway](https://github.com/ipfs/ipfs-docs-v2/pull/61)
+    - docs.ipfs.io: [docs: subdomain gateway](https://github.com/ipfs/ipfs-docs-v2/pull/61)
   - ipfs-webui:
     - Merged [feat: E2E test suite with puppeteer+ipfsd-ctl](https://github.com/ipfs-shipyard/ipfs-webui/pull/1353)
     - PR: [refactor: run all unit and e2e tests by default](https://github.com/ipfs-shipyard/ipfs-webui/pull/1373)


### PR DESCRIPTION
The legacy IPFS Docs site has been deprecated, so links to `docs-beta.ipfs.io` will auto-redirect to `docs.ipfs.io`. This PR doesn't change much from the user's perspective, but it makes things a bit tidier.